### PR TITLE
Redefine `input_event.node` in `handle_input_event`

### DIFF
--- a/doc/content/end-user-documentation/html.rst
+++ b/doc/content/end-user-documentation/html.rst
@@ -334,7 +334,7 @@ Select
 
     from lona.html import Select
 
-    CheckBox([
+    Select([
         # value, label, is_selected
         ('foo', 'Foo', True),
         ('bar', 'Bar', False),

--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -104,6 +104,8 @@ class TextInput(Widget):
         self.value = input_event.data
 
         if self.bubble_up:
+            if input_event.node is self.input_node:
+                input_event.node = self
             return input_event
 
     # properties ##############################################################

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -85,6 +85,8 @@ class Select(Widget):
             self.value = input_event.data
 
             if self.bubble_up:
+                if input_event.node is self.select_node:
+                    input_event.node = self
                 return input_event
 
     @property


### PR DESCRIPTION
Fixes #20.
Users of `TextInput` and successors (`TextArea`, `CheckBox`) expect to see `input_event.node` to be `TextInput` itself, not its attribute `.input_node`.
The same if for `Select`.
So need to update it before bubble up.