### PR TITLE
Fix typo in argument name

### DIFF
--- a/lona/server.py
+++ b/lona/server.py
@@ -364,7 +364,7 @@ class LonaServer:
                 if not isinstance(data, str):
                     raise RuntimeError('%s.handle_connection returned non string data'.format(middleware))  # NOQA
 
-                await connection.send_str(data, sync=False)
+                await connection.send_str(data, wait=False)
 
             await close_websocket()
 


### PR DESCRIPTION
Argument `sync` was removed some time ago.

@fscherf As far as I understand here we don't need `wait=False`. Am I right?