### PR TITLE
Align behaviour of `AttributeDict` and `AttributeList`

### DIFF
--- a/lona/html/attribute_list.py
+++ b/lona/html/attribute_list.py
@@ -71,11 +71,8 @@ class AttributeList:
 
     def extend(self, attributes):
         with self._node.lock:
-            for attribute in iter(attributes):
-                if attribute in self._attributes:
-                    continue
-
-                self.append(attribute)
+            for attribute in attributes:
+                self.add(attribute)
 
     def __eq__(self, other):
         with self._node.lock:

--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -38,13 +38,14 @@ class TextInput(Node):
         # The solution for this problem is to don't send patches back to users
         # who issued them.
 
-        self.attributes.__setitem__(
-            'value',
-            input_event.data,
-            issuer=(input_event.connection, input_event.window_id),
-        )
+        with self.lock:
+            self.attributes.__setitem__(
+                'value',
+                input_event.data,
+                issuer=(input_event.connection, input_event.window_id),
+            )
 
-        self.value = input_event.data
+            self.value = input_event.data
 
         if self.bubble_up:
             return input_event
@@ -62,16 +63,14 @@ class TextInput(Node):
     # disabled
     @property
     def disabled(self):
-        return self.attributes.get('disabled', '')
+        return 'disabled' in self.attributes
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.lock:
-            if new_value:
-                self.attributes['disabled'] = True
-
-            elif 'disabled' in self.attributes:
-                self.attributes.pop('disabled')
+        if new_value:
+            self.attributes['disabled'] = ''
+        else:
+            del self.attributes['disabled']
 
 
 class TextArea(TextInput):
@@ -93,8 +92,11 @@ class CheckBox(TextInput):
 
     @property
     def value(self):
-        return self.attributes.get('checked', False)
+        return 'checked' in self.attributes
 
     @value.setter
     def value(self, new_value):
-        self.attributes['checked'] = bool(new_value)
+        if new_value:
+            self.attributes['checked'] = ''
+        else:
+            del self.attributes['checked']

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -21,25 +21,22 @@ class Select(Node):
         self.disabled = disabled
 
     def handle_change(self, input_event):
-        with self.lock:
-            self.value = input_event.data
+        self.value = input_event.data
 
-            if self.bubble_up:
-                return input_event
+        if self.bubble_up:
+            return input_event
 
     # properties ##############################################################
     @property
     def disabled(self):
-        return self.attributes.get('disabled', '')
+        return 'disabled' in self.attributes
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.lock:
-            if new_value:
-                self.attributes['disabled'] = True
-
-            elif 'disabled' in self.attributes:
-                self.attributes.pop('disabled')
+        if new_value:
+            self.attributes['disabled'] = ''
+        else:
+            del self.attributes['disabled']
 
     @property
     def values(self):
@@ -79,12 +76,12 @@ class Select(Node):
 
             for option in self.nodes:
                 if 'selected' in option.attributes:
-                    value.append(option.attributes['value'])
+                    value.append(option.attributes.get('value', ''))
 
             if not value and self.nodes:
                 option = self.nodes[0]
 
-                value.append(option.attributes['value'])
+                value.append(option.attributes.get('value', ''))
 
             if not value:
                 return None
@@ -101,10 +98,7 @@ class Select(Node):
 
         with self.lock:
             for option in self.nodes:
-                if option.attributes['value'] in new_value:
-                    if 'selected' not in option.attributes:
-                        option.attributes['selected'] = ''
-
+                if option.attributes.get('value', '') in new_value:
+                    option.attributes['selected'] = ''
                 else:
-                    if 'selected' in option.attributes:
-                        option.attributes.pop('selected')
+                    del option.attributes['selected']

--- a/lona/html/node.py
+++ b/lona/html/node.py
@@ -177,11 +177,8 @@ class Node(AbstractNode):
     def ignore(self, value):
         if value:
             self._attributes['data-lona-ignore'] = 'True'
-
         else:
-            with self.lock:
-                if 'data-lona-ignore' in self._attributes:
-                    del self._attributes['data-lona-ignore']
+            del self._attributes['data-lona-ignore']
 
     # serialization ###########################################################
     def _serialize(self):
@@ -339,5 +336,5 @@ class Node(AbstractNode):
 
     def show(self):
         with self.lock:
-            if 'display' in self.style and self.style['display'] == 'none':
+            if self.style.get('display', '') == 'none':
                 del self.style['display']

--- a/lona/html/nodes.py
+++ b/lona/html/nodes.py
@@ -152,15 +152,10 @@ class Button(Node):
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.document.lock:
-            new_value = bool(new_value)
-
-            if new_value:
-                if 'disabled' not in self.attributes:
-                    self.attributes['disabled'] = 'True'
-            else:
-                if 'disabled' in self.attributes:
-                    del self.attributes['disabled']
+        if new_value:
+            self.attributes['disabled'] = ''
+        else:
+            del self.attributes['disabled']
 
 
 class Submit(Node):


### PR DESCRIPTION
`AttributeList.remove()` didn't raise exception if `attribute` not found in list. However `AttributeDict.pop()` did raise exception if `name` not found in dict.
Now they behave the same - no exception.