### PR TITLE
html: implement __contains__ with lock

### DIFF
--- a/lona/html/attribute_dict.py
+++ b/lona/html/attribute_dict.py
@@ -111,6 +111,10 @@ class AttributeDict:
         with self._node.lock:
             return self._attributes.__iter__()
 
+    def __contains__(self, name):
+        with self._node.lock:
+            return name in self._attributes
+
     def __bool__(self):
         with self._node.lock:
             return bool(self._attributes)

--- a/lona/html/attribute_list.py
+++ b/lona/html/attribute_list.py
@@ -103,6 +103,10 @@ class AttributeList:
         with self._node.lock:
             return self._attributes.__iter__()
 
+    def __contains__(self, attribute):
+        with self._node.lock:
+            return attribute in self._attributes
+
     # serialisation ###########################################################
     def _reset(self, value):
         if not isinstance(value, list):

--- a/lona/html/node_list.py
+++ b/lona/html/node_list.py
@@ -167,6 +167,10 @@ class NodeList:
         with self._node.lock:
             return self._nodes.__iter__()
 
+    def __contains__(self, node):
+        with self._node.lock:
+            return node in self._nodes
+
     # serialisation ###########################################################
     def _reset(self, value):
         if not isinstance(value, list):

--- a/lona/html/widgets.py
+++ b/lona/html/widgets.py
@@ -56,6 +56,9 @@ class HTML(Widget):
     def __iter__(self, *args, **kwargs):
         return self.nodes.__iter__(*args, **kwargs)
 
+    def __contains__(self, *args, **kwargs):
+        return self.nodes.__contains__(*args, **kwargs)
+
     def __bool__(self, *args, **kwargs):
         return self.nodes.__bool__(*args, **kwargs)
 


### PR DESCRIPTION
Before this change `__iter__` was used to execute `"disabled" in node.attributes`. And there was a chance to get `RuntimeError: dictionary changed size during iteration` in concurrent execution.
Now the whole operation is protected with lock.