### PR TITLE
html: attributes: add default to pop() and make del silent

### DIFF
--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -66,12 +66,11 @@ class TextInput(Node):
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.lock:
-            if new_value:
-                self.attributes['disabled'] = True
+        if new_value:
+            self.attributes['disabled'] = True
 
-            elif 'disabled' in self.attributes:
-                self.attributes.pop('disabled')
+        else:
+            del self.attributes['disabled']
 
 
 class TextArea(TextInput):

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -34,12 +34,11 @@ class Select(Node):
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.lock:
-            if new_value:
-                self.attributes['disabled'] = True
+        if new_value:
+            self.attributes['disabled'] = True
 
-            elif 'disabled' in self.attributes:
-                self.attributes.pop('disabled')
+        else:
+            del self.attributes['disabled']
 
     @property
     def values(self):
@@ -102,9 +101,7 @@ class Select(Node):
         with self.lock:
             for option in self.nodes:
                 if option.attributes['value'] in new_value:
-                    if 'selected' not in option.attributes:
-                        option.attributes['selected'] = ''
+                    option.attributes['selected'] = ''
 
                 else:
-                    if 'selected' in option.attributes:
-                        option.attributes.pop('selected')
+                    del option.attributes['selected']

--- a/lona/html/node.py
+++ b/lona/html/node.py
@@ -179,9 +179,7 @@ class Node(AbstractNode):
             self._attributes['data-lona-ignore'] = 'True'
 
         else:
-            with self.lock:
-                if 'data-lona-ignore' in self._attributes:
-                    del self._attributes['data-lona-ignore']
+            del self._attributes['data-lona-ignore']
 
     # serialization ###########################################################
     def _serialize(self):

--- a/lona/html/nodes.py
+++ b/lona/html/nodes.py
@@ -152,15 +152,10 @@ class Button(Node):
 
     @disabled.setter
     def disabled(self, new_value):
-        with self.document.lock:
-            new_value = bool(new_value)
-
-            if new_value:
-                if 'disabled' not in self.attributes:
-                    self.attributes['disabled'] = 'True'
-            else:
-                if 'disabled' in self.attributes:
-                    del self.attributes['disabled']
+        if new_value:
+            self.attributes['disabled'] = 'True'
+        else:
+            del self.attributes['disabled']
 
 
 class Submit(Node):

--- a/tests/test_0001_html.py
+++ b/tests/test_0001_html.py
@@ -44,6 +44,47 @@ def test_attribute_dict():
 
 
 @pytest.mark.dependency()
+def test_attribute_dict_pop():
+    from lona.html import Div
+
+    d = Div(foo='foo-val', bar='bar-val')
+
+    assert 'foo' in d.attributes
+    assert d.attributes.pop('foo') == 'foo-val'
+    assert 'foo' not in d.attributes
+
+    assert 'xxx' not in d.attributes
+    with pytest.raises(KeyError):
+        d.attributes.pop('xxx')
+    assert 'xxx' not in d.attributes
+
+    assert d.attributes.pop('xxx', 'yyy') == 'yyy'
+    assert 'xxx' not in d.attributes
+
+    assert 'bar' in d.attributes
+    assert d.attributes.pop('bar', 'yyy') == 'bar-val'
+    assert 'bar' not in d.attributes
+
+    with pytest.raises(TypeError, match='pop expected at most 2 arguments, got 3'):  # NOQA
+        d.attributes.pop('xxx', 'yyy', 'zzz')
+
+
+@pytest.mark.dependency()
+def test_attribute_dict_del():
+    from lona.html import Div
+
+    d = Div(foo='foo-val', bar='bar-val')
+
+    assert 'foo' in d.attributes
+    del d.attributes['foo']
+    assert 'foo' not in d.attributes
+
+    assert 'xxx' not in d.attributes
+    del d.attributes['xxx']
+    assert 'xxx' not in d.attributes
+
+
+@pytest.mark.dependency()
 def test_attribute_list():
     from lona.html import Div
 


### PR DESCRIPTION
* Added the second optional argument to `AttributeDict.pop`. Now `node.attributes.pop('foo', 'bar')=='bar'` if there is no `foo` in attributes.
* Now `del node.attributes['foo']` do nothing if there is no `foo` in attributes. Before `KeyError` raised.