### PR TITLE
html: data binding: always return bool for node.disabled

### DIFF
--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -62,7 +62,7 @@ class TextInput(Node):
     # disabled
     @property
     def disabled(self):
-        return self.attributes.get('disabled', '')
+        return 'disabled' in self.attributes
 
     @disabled.setter
     def disabled(self, new_value):

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -30,7 +30,7 @@ class Select(Node):
     # properties ##############################################################
     @property
     def disabled(self):
-        return self.attributes.get('disabled', '')
+        return 'disabled' in self.attributes
 
     @disabled.setter
     def disabled(self, new_value):


### PR DESCRIPTION
Before that it was possible to return empty string instead of `False`