### PR TITLE
html: data binding: fix TextInput.handle_change

### DIFF
--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -20,12 +20,20 @@ class Select(Node):
             self.values = values
         self.disabled = disabled
 
-    def handle_change(self, input_event):
-        with self.lock:
+    def handle_input_event(self, input_event):
+        if input_event.name == 'change':
             self.value = input_event.data
 
-            if self.bubble_up:
-                return input_event
+            input_event = self.handle_change(input_event)
+
+        elif input_event.name == 'click':
+            input_event = self.handle_click(input_event)
+
+        else:
+            return input_event
+
+        if self.bubble_up:
+            return input_event
 
     # properties ##############################################################
     @property

--- a/test_project/views/events/callbacks.py
+++ b/test_project/views/events/callbacks.py
@@ -1,23 +1,74 @@
-from lona.html import HTML, H2, Div, Button
+from lona.html import (
+    TextArea,
+    CheckBox,
+    TextInput,
+    Button,
+    Select,
+    HTML,
+    Div,
+    H2,
+    Br,
+)
+
 from lona import LonaView
 
 
 class InputEventCallbackView(LonaView):
-    def button_1(self, input_event):
-        self.html.query_selector('div').set_text('Button 1 was clicked')
+    def button(self, input_event):
+        self.html.query_selector('div').set_text('Button was clicked')
 
-    def button_2(self, input_event):
-        self.html.query_selector('div').set_text('Button 2 was clicked')
+    def check_box(self, input_event):
+        self.html.query_selector('div').set_text(
+            f'CheckBox was set to {input_event.node.value}',
+        )
+
+    def text_input(self, input_event):
+        self.html.query_selector('div').set_text(
+            f'TextInput was set to {input_event.node.value}',
+        )
+
+    def text_area(self, input_event):
+        self.html.query_selector('div').set_text(
+            f'TextArea was set to {input_event.node.value}',
+        )
+
+    def select(self, input_event):
+        self.html.query_selector('div').set_text(
+            f'Select was set to {input_event.node.value}',
+        )
 
     def handle_request(self, request):
         self.html = HTML(
             H2('Input Event Callbacks'),
-            Div(),
-            Button('Button 1', _id='button-1'),
-            Button('Button 2', _id='button-2'),
+            Div('Nothing was changed yet'),
+            Br(),
+
+            Button('Button', _id='button'),
+            Br(),
+
+            CheckBox(_id='check-box'),
+            Br(),
+
+            TextInput(_id='text-input'),
+            Br(),
+
+            TextArea(_id='text-area'),
+            Br(),
+
+            Select(
+                _id='select',
+                values=[
+                    ('option-1', 'Option 1'),
+                    ('option-2', 'Option 2'),
+                    ('option-3', 'Option 3'),
+                ]
+            ),
         )
 
-        self.html.query_selector('#button-1').handle_click = self.button_1
-        self.html.query_selector('#button-2').handle_click = self.button_2
+        self.html.query_selector('#button').handle_click = self.button
+        self.html.query_selector('#check-box').handle_change = self.check_box
+        self.html.query_selector('#text-input').handle_change = self.text_input
+        self.html.query_selector('#text-area').handle_change = self.text_area
+        self.html.query_selector('#select').handle_change = self.select
 
         return self.html


### PR DESCRIPTION
TextInput.handle_change gets called at the correct time, but the value of
TextInput.value gets not set before, which is counter-intuitive.

This patch sets TextInput.value in TextInput.handle_input_event() and then
calls TextInput.handle_change(). This patch also adds a test view for this
feature to the test project.

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>