### PR TITLE
Fscherf/topic/fix custom input events

### DIFF
--- a/lona/client/input-events.js
+++ b/lona/client/input-events.js
@@ -85,7 +85,6 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
                 };
 
                 input_event_handler.fire_input_event(
-                    undefined,
                     node,
                     Lona.protocol.INPUT_EVENT_TYPE.CLICK,
                     event_data,
@@ -121,7 +120,6 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
                             var value = input_event_handler._get_value(node);
 
                             input_event_handler.fire_input_event(
-                                undefined,
                                 node,
                                 Lona.protocol.INPUT_EVENT_TYPE.CHANGE,
                                 value,
@@ -148,7 +146,6 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
                 var value = input_event_handler._get_value(node);
 
                 input_event_handler.fire_input_event(
-                    undefined,
                     node,
                     Lona.protocol.INPUT_EVENT_TYPE.CHANGE,
                     value,
@@ -294,7 +291,7 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
         });
     };
 
-    this.fire_input_event = function(widget_id, node, event_type, data) {
+    this.fire_input_event = function(node, event_type, data) {
         var _this = this;
 
         if(this.lona_window._crashed) {
@@ -311,7 +308,10 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
         var node_id = undefined;
         var node_class = undefined;
 
-        if(node) {
+        if(typeof node == 'string') {
+            lona_node_id = node;
+
+        } else if(node) {
             lona_node_id = node.getAttribute('data-lona-node-id');
             node_tag_name = node.tagName;
             node_id = node.id || '';
@@ -325,7 +325,6 @@ Lona.LonaInputEventHandler = function(lona_context, lona_window) {
             event_id,
             event_type,
             data,
-            widget_id,
             lona_node_id,
             node_tag_name,
             node_id,

--- a/lona/client/window-shim.js
+++ b/lona/client/window-shim.js
@@ -6,8 +6,7 @@ Lona.LonaWindowShim = function(lona_context, lona_window, widget_id) {
 
     this.fire_input_event = function(node, event_type, data) {
         return this._lona_window._input_event_handler.fire_input_event(
-            this._widget_id,
-            node,
+            node || this._widget_id,
             event_type,
             data,
         );

--- a/lona/events/input_event.py
+++ b/lona/events/input_event.py
@@ -40,15 +40,15 @@ class InputEvent:
 
         # find node
         # node info contains a lona node id
-        if self.node_info[0] or self.node_info[1]:
-            self.nodes = document.get_node(node_id=self.node_info[1])
+        if self.node_info[0]:
+            self.nodes = document.get_node(node_id=self.node_info[0])
 
             if self.nodes:
                 self.node = self.nodes[0]
 
-        self.tag_name = self.node_info[2]
-        self.id_list = (self.node_info[3] or '').split(' ')
-        self.class_list = (self.node_info[4] or '').split(' ')
+        self.tag_name = self.node_info[1]
+        self.id_list = (self.node_info[2] or '').split(' ')
+        self.class_list = (self.node_info[3] or '').split(' ')
 
     def node_has_id(self, name):
         if self.node is None:

--- a/test_project/views/frontend/custom_event.py
+++ b/test_project/views/frontend/custom_event.py
@@ -42,8 +42,7 @@ class CustomEventWidget(Widget):
 
     def handle_input_event(self, input_event):
         data = {
-            'node': input_event.node,
-            'node_info': input_event.node_info,
+            'node': input_event.node.id,
             'type': input_event.type,
             'name': input_event.name,
             'data': input_event.data,


### PR DESCRIPTION
Custom input events which are not related to a node broke between 1.4.1 and 1.5. This can be reproduced using the test_project under the url ``/frontend/custom-event/``

https://lona-web.org/end-user-documentation/html.html#firing-custom-input-events