### PR TITLE
cosmetics: use %r for logging instead of repr()

### DIFF
--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -43,8 +43,8 @@ def _find_node_classes(module):
             if node_class.TAG_NAME == 'input':
                 if 'type' not in node_class.ATTRIBUTES:
                     logger.warning(
-                        'WARNING: input node %s has no type set',
-                        repr(node_class),
+                        'WARNING: input node %r has no type set',
+                        node_class,
                     )
 
                     continue

--- a/lona/middleware_controller.py
+++ b/lona/middleware_controller.py
@@ -104,19 +104,10 @@ class MiddlewareController:
         if hook_name not in self.hooks:
             raise NotImplementedError("unknown hook '{}'".format(hook_name))
 
-        logger.debug(
-            'running %s with %s',
-            hook_name,
-            repr(data),
-        )
+        logger.debug('running %s with %r', hook_name, data)
 
         for middleware, hook in self.hooks[hook_name]:
-            logger.debug(
-                'running %s.%s(%s)',
-                middleware,
-                hook_name,
-                repr(data),
-            )
+            logger.debug('running %s.%s(%r)', middleware, hook_name, data)
 
             # run middleware hook
             return_value = hook(data)
@@ -135,10 +126,10 @@ class MiddlewareController:
                 # is considered as handled
 
                 logger.debug(
-                    'data got handled by %s.%s by returning a custom value: %s',  # NOQA
+                    'data got handled by %s.%s by returning a custom value: %r',  # NOQA: E501
                     middleware,
                     hook_name,
-                    repr(return_value),
+                    return_value,
                 )
 
                 return True, return_value, middleware
@@ -151,27 +142,18 @@ class MiddlewareController:
         if hook_name not in self.hooks:
             raise NotImplementedError("unknown hook '{}'".format(hook_name))
 
-        logger.debug(
-            'running %s with %s',
-            hook_name,
-            repr(data),
-        )
+        logger.debug('running %s with %r', hook_name, data)
 
         for middleware, hook in self.hooks[hook_name]:
-            logger.debug(
-                'running %s.%s(%s)',
-                middleware,
-                hook_name,
-                repr(data),
-            )
+            logger.debug('running %s.%s(%r)', middleware, hook_name, data)
 
             try:
                 await hook(data)
 
             except Exception:
                 logger.error(
-                    'Exception raised while running %s',
-                    repr(hook),
+                    'Exception raised while running %r',
+                    hook,
                     exc_info=True,
                 )
 

--- a/lona/response_parser.py
+++ b/lona/response_parser.py
@@ -62,7 +62,7 @@ class ResponseParser:
                     response_dict[key] = value
 
                     logger.debug(
-                        "'%s' sets '%s' to %s", view_name, key, repr(value))
+                        "'%s' sets '%s' to %r", view_name, key, value)
 
         # redirects
         if 'redirect' in raw_response_dict:

--- a/lona/server.py
+++ b/lona/server.py
@@ -134,7 +134,7 @@ class LonaServer:
 
         static_url = self.settings.STATIC_URL_PREFIX + '{path:.*}'
 
-        server_logger.debug('static url set to %s', repr(static_url))
+        server_logger.debug('static url set to %r', static_url)
 
         self._app.router.add_route(
             '*', static_url, self._handle_static_file_request)
@@ -396,7 +396,7 @@ class LonaServer:
         http_logger.debug('http request incoming')
 
         # resolve path
-        http_logger.debug("resolving path %s", repr(http_request.path))
+        http_logger.debug("resolving path %r", http_request.path)
 
         match, route, match_info = await self.run_function_async(
             self.router.resolve,

--- a/lona/static_file_loader.py
+++ b/lona/static_file_loader.py
@@ -63,10 +63,10 @@ class StaticFileLoader:
                 # check static file
                 if not isinstance(static_file, StaticFile):
                     logger.error(
-                        '%s::%s: unknown type found: %s',
+                        '%s::%s: unknown type found: %r',
                         node_class_path,
                         node_class.__name__,
-                        repr(static_file),
+                        static_file,
                     )
 
                     continue

--- a/lona/view_runtime_controller.py
+++ b/lona/view_runtime_controller.py
@@ -192,10 +192,7 @@ class ViewRuntimeController:
             )
 
             if running_view_runtime and not running_view_runtime.is_stopped:
-                views_logger.debug(
-                    'reconnecting to %s',
-                    repr(running_view_runtime),
-                )
+                views_logger.debug('reconnecting to %r', running_view_runtime)
 
                 running_view_runtime.reconnect_connection(
                     connection=connection,
@@ -289,7 +286,7 @@ class ViewRuntimeController:
 
         # views
         if method == METHOD.VIEW:
-            views_logger.debug('view message decoded: %s', repr(payload))
+            views_logger.debug('view message decoded: %r', payload)
 
             self.handle_view_message(
                 connection=connection,


### PR DESCRIPTION
It also may increase performance a bit because of lazy formatting. `repr` may even not be called depending on selected log level.