### PR TITLE
html: Submit, Reset: remove lona click events

### DIFF
--- a/lona/html/nodes.py
+++ b/lona/html/nodes.py
@@ -161,7 +161,6 @@ class Button(Node):
 class Submit(Node):
     TAG_NAME = 'input'
     SELF_CLOSING_TAG = True
-    EVENTS = [CLICK]
 
     ATTRIBUTES = {
         'type': 'submit',
@@ -172,7 +171,6 @@ class Submit(Node):
 class Reset(Node):
     TAG_NAME = 'input'
     SELF_CLOSING_TAG = True
-    EVENTS = [CLICK]
 
     ATTRIBUTES = {
         'type': 'reset',

--- a/lona/html/nodes.py
+++ b/lona/html/nodes.py
@@ -168,16 +168,6 @@ class Submit(Node):
     }
 
 
-class Reset(Node):
-    TAG_NAME = 'input'
-    SELF_CLOSING_TAG = True
-
-    ATTRIBUTES = {
-        'type': 'reset',
-        'value': 'Reset',
-    }
-
-
 # complex html nodes ##########################################################
 class Img(Node):
     TAG_NAME = 'img'


### PR DESCRIPTION
Since we restructured click and change events, Submit and Reset catch their own click events, which breaks traditional froms
(test project url: /view-types/form-view/)