### PR TITLE
tests: split long tests to class methods

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-addopts= tests -v -rsx --tb=long --cov-report=xml --cov-report=html:htmlcov --cov-report=term:skip-covered
+addopts= tests -v -rsx --tb=long --strict-markers --cov-report=xml --cov-report=html:htmlcov --cov-report=term:skip-covered
+markers =
+    incremental: marks test class to stop execution after the first test method failed
 log_cli=false
 log_level=NOTSET
 log_format = %(levelname)-8s %(name)-30s [%(asctime)s.%(msecs)03d] %(message)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+from typing import Dict, Tuple
+import pytest
+
+# see https://docs.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps  # NOQA: E501
+
+# store history of failures per test class name
+# and per index in parametrize (if parametrize used)
+_test_failed_incremental: Dict[str, Dict[Tuple[int, ...], str]] = {}
+
+
+def pytest_runtest_makereport(item, call):
+    if 'incremental' in item.keywords:
+        # incremental marker is used
+        if call.excinfo is not None:
+            # the test has failed
+            # retrieve the class name of the test
+            cls_name = str(item.cls)
+            # retrieve the index of the test
+            # (if parametrize is used in combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, 'callspec')
+                else ()
+            )
+            # retrieve the name of the test function
+            test_name = item.originalname or item.name
+            # store in _test_failed_incremental
+            # the original name of the failed test
+            _test_failed_incremental.setdefault(cls_name, {}).setdefault(
+                parametrize_index, test_name
+            )
+
+
+def pytest_runtest_setup(item):
+    if 'incremental' in item.keywords:
+        # retrieve the class name of the test
+        cls_name = str(item.cls)
+        # check if a previous test has failed for this class
+        if cls_name in _test_failed_incremental:
+            # retrieve the index of the test
+            # (if parametrize is used in combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, 'callspec')
+                else ()
+            )
+            # retrieve the name of the first test function
+            # to fail for this class name and index
+            test_name = _test_failed_incremental[cls_name].get(
+                parametrize_index,
+                None,
+            )
+            # if name found, test has failed
+            # for the combination of class name & test name
+            if test_name is not None:
+                pytest.xfail(f'previous test failed ({test_name})')

--- a/tests/test_0100_components.py
+++ b/tests/test_0100_components.py
@@ -2,8 +2,52 @@ import pytest
 
 
 @pytest.mark.dependency(depends=[
-    'tests/test_0001_html.py::test_attribute_dict',
-    'tests/test_0001_html.py::test_attribute_list',
+    # see https://github.com/RKrahl/pytest-dependency/issues/55
+    'tests/test_0001_html.py::TestAttributeDict::test_get_initial_values',
+    'tests/test_0001_html.py::TestAttributeDict::test_set_attributes',
+    'tests/test_0001_html.py::TestAttributeDict::test_value_cant_be_dict',
+    'tests/test_0001_html.py::TestAttributeDict::test_cant_use_id_key',
+    'tests/test_0001_html.py::TestAttributeDict::test_empty_dict_is_false',
+    'tests/test_0001_html.py::TestAttributeDict::test_non_empty_dict_is_true',
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_existing_key',
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_unknown_key',
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_unknown_key_with_default',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_existing_key_with_default',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_expects_at_most_2_arguments',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeDict::test_del_existing_key',
+    'tests/test_0001_html.py::TestAttributeDict::test_del_unknown_key',
+    'tests/test_0001_html.py::TestAttributeList::test_add_existing_element_does_nothing',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_add_one_element',
+    'tests/test_0001_html.py::TestAttributeList::test_cant_add_dict',
+    'tests/test_0001_html.py::TestAttributeList::test_cant_set_dict',
+    'tests/test_0001_html.py::TestAttributeList::test_cant_set_list_with_dict',
+    'tests/test_0001_html.py::TestAttributeList::test_clear',
+    'tests/test_0001_html.py::TestAttributeList::test_clear_empty_list',
+    'tests/test_0001_html.py::TestAttributeList::test_default_class_list_is_empty',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_default_id_list_is_empty',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_default_list_has_zero_len',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_empty_list_is_false',
+    'tests/test_0001_html.py::TestAttributeList::test_equality_ignored_duplicates',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_equality_ignores_order',
+    'tests/test_0001_html.py::TestAttributeList::test_extend',
+    'tests/test_0001_html.py::TestAttributeList::test_extend_ignores_duplicates',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_in_keyword',
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_list',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_passed_via_kwargs',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_space_separated_str',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_list',
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_passed_via_kwargs',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_space_separated_str',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_cant_be_dict',
+    'tests/test_0001_html.py::TestAttributeList::test_len_returns_number_of_elements',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_non_empty_list_is_true',
+    'tests/test_0001_html.py::TestAttributeList::test_non_equality',
+    'tests/test_0001_html.py::TestAttributeList::test_remove_existing_element',
+    'tests/test_0001_html.py::TestAttributeList::test_remove_unknown_element',
+    'tests/test_0001_html.py::TestAttributeList::test_set_class_list',
+    'tests/test_0001_html.py::TestAttributeList::test_set_id_list',
+    'tests/test_0001_html.py::TestAttributeList::test_toggle_existing_element',
+    'tests/test_0001_html.py::TestAttributeList::test_toggle_unknown_element',
 ], scope='session')
 def test_node_api():
     pass


### PR DESCRIPTION
Here is why we had a long test functions: https://github.com/lona-web-org/lona/pull/61#discussion_r702608329.

Now we use test class methods in combination with custom `@pytest.mark.incremental()` from [here](https://docs.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps).

The only downside is that we can't mark that test depends on all methods in class, but have to list them all (see RKrahl/pytest-dependency#55).