### PR TITLE
html: fix node list operations

### DIFF
--- a/doc/content/end-user-documentation/views.rst
+++ b/doc/content/end-user-documentation/views.rst
@@ -439,8 +439,13 @@ Input Events
 
 .. note::
 
-    Changed in 1.5: In all versions prior to 1.5, only widgets could handle
+    **Changed in 1.5:** In all versions prior to 1.5, only widgets could handle
     their own events. In versions after 1.5 all node classes can.
+
+    **Changed in 1.7:** In all versions prior to 1.7, ``==`` checked if two
+    nodes have equal attributes, but did not check if node A is the same node
+    as node B.  To check if node A is node B is ``is`` instead of ``==`` was
+    required.
 
 Input events get handled in a chain of hooks. Every hook is required to return
 the given input event, to pass it down the chain, or return ``None`` to mark
@@ -456,14 +461,6 @@ If the event got returned by the last widget in the chain, Lona checks if
 
 Input events can, but don't have to, contain a node that issued the event in
 ``input_event.node``.
-
-.. note::
-
-    Be careful when comparing ``input_event.node`` with another node.
-    ``==`` checks if two nodes have equal attributes, bot does not check if
-    node A is the same node as node B.
-
-    To check if node A is node B us ``is`` instead of ``==``.
 
 
 Input Event types

--- a/lona/html/node.py
+++ b/lona/html/node.py
@@ -322,30 +322,6 @@ class Node(AbstractNode):
     def __repr__(self):
         return self.__str__()
 
-    # comparisons #############################################################
-    def __eq__(self, other):
-        if not isinstance(other, Node):
-            return False
-
-        # campare attributes
-        return (
-            self.tag_name,
-            self.self_closing_tag,
-            self._id_list,
-            self._class_list,
-            self._style,
-            self._attributes,
-            self._nodes,
-        ) == (
-            other.tag_name,
-            other.self_closing_tag,
-            other._id_list,
-            other._class_list,
-            other._style,
-            other._attributes,
-            other._nodes,
-        )
-
     # HTML helper #############################################################
     def set_text(self, text):
         self.nodes = [str(text)]

--- a/lona/html/text_node.py
+++ b/lona/html/text_node.py
@@ -6,12 +6,6 @@ class TextNode(AbstractNode):
     def __init__(self, string):
         self._string = str(string)
 
-    def __eq__(self, other):
-        if isinstance(other, TextNode):
-            other = other._string
-
-        return self._string == other
-
     def wrap_method(self, method):
         def wrapper(*args, **kwargs):
             return_value = method(*args, **kwargs)


### PR DESCRIPTION
Previously nodes had a special ``__eq__()`` method that made high level comparisons
between nodes possible.

    Div(a=1) == Div(a=1) -> True
    Div(a=1) == Div(b=1) -> False

This feature was intended to be used for testing purposes in the future.

The problem with this implementation is that methods like list.index() or
list.remove() use ``__eq__()`` to find an list item.

    d1 = Div()
    d2 = Div()
    l = [d1, d2]

    l.index(d1) -> 0
    l.index(d2) -> 0

This breaks patch generating and a lot of potential application code.

@maratori Could you review this?