### PR TITLE
Use isort to keep imports consistent

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,17 @@
+[settings]
+# skip all files ignored by git
+skip_gitignore=True
+
+# is used in demos
+known_lonaplugins=lona_bootstrap_5,lona_chartjs,lona_django
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LONAPLUGINS,LOCALFOLDER
+
+# reverse christmas tree ordering (long lines before short lines)
+length_sort=True
+reverse_sort=True
+force_sort_within_sections=True
+
+# vertical hanging
+multi_line_output=3
+
+include_trailing_comma=True

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON_ENV_ROOT=envs
 PYTHON_DEV_ENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-dev
 PYTHON_PACKAGING_ENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-packaging-env
 
-.PHONY: clean doc sdist test ci-test lint shell freeze
+.PHONY: clean doc sdist test ci-test lint isort shell freeze
 
 # development environment #####################################################
 $(PYTHON_DEV_ENV)/.created: REQUIREMENTS.dev.txt
@@ -56,6 +56,11 @@ ci-test: dev-env
 lint: dev-env
 	. $(PYTHON_DEV_ENV)/bin/activate && \
 	time tox -e lint
+
+# isort #######################################################################
+isort: dev-env
+	. $(PYTHON_DEV_ENV)/bin/activate && \
+	tox -e isort
 
 # packaging ###################################################################
 sdist: packaging-env

--- a/doc/content/demos/bootstrap-5-confirmation-popup/bootstrap-5-confirmation-popup.py
+++ b/doc/content/demos/bootstrap-5-confirmation-popup/bootstrap-5-confirmation-popup.py
@@ -1,5 +1,5 @@
-from lona.html import HTML, H1, Table, Tr, Th, Td, THead, TBody, Strong
-from lona import LonaApp, LonaView
+from lona.html import Strong, THead, TBody, Table, Tr, Th, Td, HTML, H1
+from lona import LonaView, LonaApp
 
 from lona_bootstrap_5 import (
     SecondaryButton,

--- a/doc/content/demos/chartjs-click-analyzer/chartjs-click-analyzer.py
+++ b/doc/content/demos/chartjs-click-analyzer/chartjs-click-analyzer.py
@@ -1,5 +1,5 @@
-from lona.html import HTML, H1, Div, Strong, Button, CLICK
-from lona import LonaApp, LonaView
+from lona.html import Strong, Button, Div, CLICK, HTML, H1
+from lona import LonaView, LonaApp
 
 from lona_chartjs import Chart
 

--- a/doc/content/demos/counter/counter.py
+++ b/doc/content/demos/counter/counter.py
@@ -1,5 +1,5 @@
-from lona.html import HTML, H1, Span, NumberInput, Button
-from lona import LonaApp, LonaView
+from lona.html import NumberInput, Button, Span, HTML, H1
+from lona import LonaView, LonaApp
 
 app = LonaApp(__file__)
 

--- a/doc/content/demos/daemonized-view/daemonized-view.py
+++ b/doc/content/demos/daemonized-view/daemonized-view.py
@@ -1,7 +1,7 @@
 import random
 
-from lona.html import HTML, H1, Button
-from lona import LonaApp, LonaView
+from lona.html import Button, HTML, H1
+from lona import LonaView, LonaApp
 
 from lona_chartjs import Chart
 

--- a/doc/content/demos/game-of-life/game-of-life.py
+++ b/doc/content/demos/game-of-life/game-of-life.py
@@ -1,7 +1,7 @@
 import numpy
 
-from lona.html import HTML, H1, Div, NumberInput, Button, CLICK, Span
-from lona import LonaApp, LonaView
+from lona.html import NumberInput, Button, Span, Div, CLICK, HTML, H1
+from lona import LonaView, LonaApp
 
 app = LonaApp(__file__)
 

--- a/doc/content/how-to-contribute.rst
+++ b/doc/content/how-to-contribute.rst
@@ -23,6 +23,13 @@ Linters
 To run the linters go to ``lona/`` and run ``make lint``.
 
 
+Sort Imports
+-------
+
+To keep imports consistent run ``make isort`` in repo's root.
+It automatically sorts imports in all files.
+
+
 Test Project
 ------------
 

--- a/doc/plugins/changelog.py
+++ b/doc/plugins/changelog.py
@@ -1,7 +1,6 @@
+from flamingo.plugins.rst import register_directive
 from docutils.parsers.rst import Directive
 from docutils.nodes import raw
-
-from flamingo.plugins.rst import register_directive
 
 GITHUB_RELEASES_BASE_URL = 'https://github.com/lona-web-org/lona/releases/tag/'
 

--- a/doc/plugins/pygments.py
+++ b/doc/plugins/pygments.py
@@ -3,17 +3,15 @@
 from tempfile import TemporaryDirectory
 import os
 
-from docutils.parsers.rst import Directive, directives
-from docutils.nodes import raw
-
+from pygments.styles import get_style_by_name, get_all_styles
 from pygments.lexers import get_lexer_by_name, guess_lexer
-from pygments.styles import get_all_styles, get_style_by_name
+from docutils.parsers.rst import directives, Directive
+from flamingo.plugins.rst import register_directive
 from pygments.formatters import HtmlFormatter
 from pygments.util import ClassNotFound
 from pygments.token import Token
 from pygments import highlight
-
-from flamingo.plugins.rst import register_directive
+from docutils.nodes import raw
 
 
 def code_block(context):

--- a/doc/plugins/rst_setting.py
+++ b/doc/plugins/rst_setting.py
@@ -1,15 +1,13 @@
 # source: https://github.com/pengutronix/flamingo/blob/master/doc/plugins/rst_setting.py  # NOQA: E501
 
-from docutils.parsers.rst import Directive, directives
-from docutils.nodes import raw
-
-from pygments.formatters import HtmlFormatter
-from pygments.lexers import get_lexer_by_name
-from pygments import highlight
-
+from docutils.parsers.rst import directives, Directive
 from flamingo.core.utils.imports import acquire
 from flamingo.core.utils.pprint import pformat
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import HtmlFormatter
 from flamingo.plugins.rst import parse_rst
+from pygments import highlight
+from docutils.nodes import raw
 
 RAW_SETTING_TEMPLATE = """
 <div class="raw-setting">

--- a/doc/plugins/toc_tree.py
+++ b/doc/plugins/toc_tree.py
@@ -1,7 +1,7 @@
 import re
 
-from jinja2 import Template
 from bs4 import BeautifulSoup
+from jinja2 import Template
 
 FUNCTION_RE = re.compile(r'\([^)]+\)')
 

--- a/lona/__init__.py
+++ b/lona/__init__.py
@@ -1,9 +1,9 @@
 try:
+    from .exceptions import *  # NOQA: F403
     from .routing import Route, MATCH_ALL
+    from .errors import *  # NOQA: F403
     from .view import LonaView
     from .app import LonaApp
-    from .exceptions import *  # NOQA: F403
-    from .errors import *  # NOQA: F403
 
 except ImportError:
     # this happens while packaging and can be ignored

--- a/lona/app.py
+++ b/lona/app.py
@@ -2,14 +2,14 @@ from tempfile import TemporaryDirectory
 import logging
 import os
 
+from aiohttp.web import Application
+
 from lona.command_line.run_server import run_server
 from lona.logging import setup_logging
 from lona.settings import Settings
 from lona.server import LonaServer
 from lona import default_settings
 from lona.routing import Route
-
-from aiohttp.web import Application
 
 logger = logging.getLogger('lona.app')
 

--- a/lona/client_pre_compiler.py
+++ b/lona/client_pre_compiler.py
@@ -2,7 +2,7 @@ from tempfile import TemporaryDirectory
 import logging
 import os
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader, Environment
 
 from lona.protocol import ENUMS
 from lona._json import dumps

--- a/lona/command_line/handle_command_line.py
+++ b/lona/command_line/handle_command_line.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import RawTextHelpFormatter, ArgumentParser
 import logging
 import sys
 import os

--- a/lona/command_line/run_server.py
+++ b/lona/command_line/run_server.py
@@ -1,12 +1,12 @@
-import asyncio
 import logging
-import signal
+import asyncio
 import socket
+import signal
 import os
 
-from aiohttp.web import Application, run_app
+from aiohttp.web import run_app, Application
 
-from lona.shell.shell import embed_shell, generate_shell_server
+from lona.shell.shell import generate_shell_server, embed_shell
 from lona.worker_pool import WorkerPool
 from lona.logging import setup_logging
 from lona.server import LonaServer

--- a/lona/default_settings.py
+++ b/lona/default_settings.py
@@ -1,5 +1,5 @@
-import os
 from typing import List, Dict, Any
+import os
 
 MAX_WORKER_THREADS = 4
 MAX_STATIC_THREADS = 4

--- a/lona/html/__init__.py
+++ b/lona/html/__init__.py
@@ -1,9 +1,8 @@
 from lona.html.data_binding.select import *  # NOQA: F403
 from lona.html.data_binding.inputs import *  # NOQA: F403
+from lona.html.parsing import _setup_node_classes_cache
+from lona.html.nodes import *  # NOQA: F403
 from lona.html.widget import Widget
 from lona.html.widgets import HTML
-from lona.html.nodes import *  # NOQA: F403
-
-from lona.html.parsing import _setup_node_classes_cache
 
 _setup_node_classes_cache()

--- a/lona/html/attribute_dict.py
+++ b/lona/html/attribute_dict.py
@@ -1,4 +1,4 @@
-from lona.protocol import OPERATION, PATCH_TYPE
+from lona.protocol import PATCH_TYPE, OPERATION
 
 
 class AttributeDict:

--- a/lona/html/attribute_list.py
+++ b/lona/html/attribute_list.py
@@ -1,4 +1,4 @@
-from lona.protocol import OPERATION, PATCH_TYPE
+from lona.protocol import PATCH_TYPE, OPERATION
 
 
 class AttributeList:

--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any
+from typing import Optional, Dict, Any
 
 from lona.events.event_types import CHANGE
 from lona.html.node import Node

--- a/lona/html/node.py
+++ b/lona/html/node.py
@@ -1,10 +1,10 @@
+from typing import Union, List, Dict
 from textwrap import indent
-from typing import List, Dict, Union
 
-from lona.events import EventType, ChangeEventType
 from lona.html.attribute_dict import AttributeDict, StyleDict
-from lona.html.attribute_list import IDList, ClassList
+from lona.html.attribute_list import ClassList, IDList
 from lona.html.node_event_list import NodeEventList
+from lona.events import ChangeEventType, EventType
 from lona.html.abstract_node import AbstractNode
 from lona.html.node_list import NodeList
 from lona.protocol import NODE_TYPE

--- a/lona/html/node_list.py
+++ b/lona/html/node_list.py
@@ -1,5 +1,5 @@
 from lona.html.abstract_node import AbstractNode
-from lona.protocol import OPERATION, PATCH_TYPE
+from lona.protocol import PATCH_TYPE, OPERATION
 from lona.html.text_node import TextNode
 
 

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -1,7 +1,7 @@
 from html.parser import HTMLParser
-from typing import Dict, Type
-import inspect
+from typing import Type, Dict
 import logging
+import inspect
 
 from lona.html.text_node import TextNode
 from lona.html.node import Node

--- a/lona/html/widget_data.py
+++ b/lona/html/widget_data.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from lona.protocol import OPERATION, PATCH_TYPE
+from lona.protocol import PATCH_TYPE, OPERATION
 
 
 def check_value(value):

--- a/lona/middleware_controller.py
+++ b/lona/middleware_controller.py
@@ -1,5 +1,5 @@
-import asyncio
 import logging
+import asyncio
 
 logger = logging.getLogger('lona.middlewares')
 

--- a/lona/middlewares/lona_messages.py
+++ b/lona/middlewares/lona_messages.py
@@ -1,6 +1,6 @@
 import logging
 
-from lona.protocol import PROTOCOL, EXIT_CODE, decode_message
+from lona.protocol import decode_message, EXIT_CODE, PROTOCOL
 
 logger = logging.getLogger('lona.protocol')
 

--- a/lona/middlewares/sessions.py
+++ b/lona/middlewares/sessions.py
@@ -1,5 +1,5 @@
-import random
 import string
+import random
 
 from aiohttp.web import Response
 

--- a/lona/protocol.py
+++ b/lona/protocol.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Dict, Union
+from typing import Optional, Union, Tuple, Dict
 from enum import Enum
 import json
 

--- a/lona/server.py
+++ b/lona/server.py
@@ -1,18 +1,12 @@
 from functools import reduce
 import operator
-import asyncio
 import logging
 import inspect
+import asyncio
 import os
 
+from aiohttp.web import WebSocketResponse, FileResponse, HTTPFound, Response
 from aiohttp import WSMsgType
-
-from aiohttp.web import (
-    WebSocketResponse,
-    FileResponse,
-    HTTPFound,
-    Response,
-)
 
 from lona.view_runtime_controller import ViewRuntimeController
 from lona.middleware_controller import MiddlewareController

--- a/lona/shell/commands/lona_routes.py
+++ b/lona/shell/commands/lona_routes.py
@@ -1,6 +1,6 @@
+from rlpython.utils.attribute_table import write_attribute_table
 from rlpython.utils.argument_parser import ReplArgumentParser
 from rlpython.utils.table import write_table
-from rlpython.utils.attribute_table import write_attribute_table
 
 
 class LonaRoutesCommand:

--- a/lona/shell/commands/lona_views.py
+++ b/lona/shell/commands/lona_views.py
@@ -1,4 +1,4 @@
-import __main__
+import __main__  # isort: skip
 
 from pprint import pformat
 import traceback

--- a/lona/static_file_loader.py
+++ b/lona/static_file_loader.py
@@ -2,7 +2,7 @@ from copy import copy
 import logging
 import os
 
-from lona.static_files import StaticFile, StyleSheet, Script
+from lona.static_files import StyleSheet, StaticFile, Script
 from lona.html.abstract_node import AbstractNode
 from lona.imports import get_file
 

--- a/lona/templating.py
+++ b/lona/templating.py
@@ -2,7 +2,7 @@ import builtins
 import logging
 import os
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader, Environment
 
 logger = logging.getLogger('lona.templating')
 

--- a/lona/view.py
+++ b/lona/view.py
@@ -1,6 +1,6 @@
+from typing import List, Dict
 import threading
 import asyncio
-from typing import Dict, List
 
 from lona.view_runtime import VIEW_RUNTIME_STATE
 from lona.shell.shell import embed_shell

--- a/lona/view_loader.py
+++ b/lona/view_loader.py
@@ -1,6 +1,6 @@
-import asyncio
 import logging
 import inspect
+import asyncio
 
 from lona.view import LonaView
 

--- a/lona/view_runtime.py
+++ b/lona/view_runtime.py
@@ -8,16 +8,6 @@ import time
 
 from yarl import URL
 
-from lona.exceptions import StopReason, ServerStop, UserAbort
-from lona.html.abstract_node import AbstractNode
-from lona.events.input_event import InputEvent
-from lona.unique_ids import generate_unique_id
-from lona.imports import get_object_repr
-from lona.html.document import Document
-from lona.errors import ForbiddenError
-from lona.errors import ClientError
-from lona.request import Request
-
 from lona.protocol import (
     encode_input_event_ack,
     encode_http_redirect,
@@ -27,7 +17,14 @@ from lona.protocol import (
     encode_data,
     DATA_TYPE,
 )
-
+from lona.exceptions import StopReason, ServerStop, UserAbort
+from lona.errors import ForbiddenError, ClientError
+from lona.html.abstract_node import AbstractNode
+from lona.unique_ids import generate_unique_id
+from lona.events.input_event import InputEvent
+from lona.imports import get_object_repr
+from lona.html.document import Document
+from lona.request import Request
 
 logger = logging.getLogger('lona.view_runtime')
 input_events_logger = logging.getLogger('lona.input_events')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from lona import VERSION_STRING
 

--- a/test_project/routes.py
+++ b/test_project/routes.py
@@ -1,6 +1,5 @@
 from lona.routing import Route
 
-
 routes = [
     # view types
     Route('/view-types/interactive-view/',

--- a/test_project/views/crashes/frontend_widget.py
+++ b/test_project/views/crashes/frontend_widget.py
@@ -1,5 +1,5 @@
 from lona.static_files import Script
-from lona.html import HTML, Widget
+from lona.html import Widget, HTML
 from lona.view import LonaView
 
 

--- a/test_project/views/crashes/input_events.py
+++ b/test_project/views/crashes/input_events.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lona.html import Widget, Button, HTML, Div, Br, H2
+from lona.html import Widget, Button, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/events/callbacks.py
+++ b/test_project/views/events/callbacks.py
@@ -1,15 +1,14 @@
 from lona.html import (
+    TextInput,
     TextArea,
     CheckBox,
-    TextInput,
-    Button,
     Select,
-    HTML,
+    Button,
     Div,
-    H2,
     Br,
+    HTML,
+    H2,
 )
-
 from lona import LonaView
 
 

--- a/test_project/views/events/change_events.py
+++ b/test_project/views/events/change_events.py
@@ -1,6 +1,6 @@
 from pprint import pformat
 
-from lona.html import TextInput, CheckBox, Div, H2, Pre
+from lona.html import TextInput, CheckBox, Pre, Div, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/events/class_based_view.py
+++ b/test_project/views/events/class_based_view.py
@@ -1,4 +1,4 @@
-from lona.html import HTML, Button, Div, Br, H2
+from lona.html import Button, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/events/click_events.py
+++ b/test_project/views/events/click_events.py
@@ -1,6 +1,6 @@
 from pprint import pformat
 
-from lona.html import Div, H2, Pre, Br, A
+from lona.html import Pre, Div, Br, A, H2
 from lona.view import LonaView
 from lona.events import CLICK
 

--- a/test_project/views/events/data_binding.py
+++ b/test_project/views/events/data_binding.py
@@ -1,19 +1,18 @@
 from pprint import pformat
 
-from lona.view import LonaView
-
 from lona.html import (
     NumberInput,
     TextInput,
-    CheckBox,
     TextArea,
-    Button,
+    CheckBox,
     Select,
-    HTML,
-    Div,
-    H2,
+    Button,
     Pre,
+    Div,
+    HTML,
+    H2,
 )
+from lona.view import LonaView
 
 
 class DataBindingView(LonaView):

--- a/test_project/views/events/event_bubbling.py
+++ b/test_project/views/events/event_bubbling.py
@@ -1,15 +1,5 @@
+from lona.html import Widget, Select, Button, Pre, Div, P, HTML, H2
 from lona.view import LonaView
-
-from lona.html import (
-    Select,
-    Widget,
-    Button,
-    HTML,
-    Div,
-    Pre,
-    H2,
-    P,
-)
 
 
 class BubblingWidget(Widget):

--- a/test_project/views/events/widget_event_handler.py
+++ b/test_project/views/events/widget_event_handler.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lona.html import HTML, Button, Widget, Div, Br, H2
+from lona.html import Widget, Button, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/frontend/custom_event.py
+++ b/test_project/views/frontend/custom_event.py
@@ -1,6 +1,6 @@
 from pprint import pformat
 
-from lona.html import HTML, Div, H2, Widget, Button, Pre, A
+from lona.html import Widget, Button, Pre, Div, A, HTML, H2
 from lona.static_files import Script
 from lona.view import LonaView
 

--- a/test_project/views/frontend/custom_messages.py
+++ b/test_project/views/frontend/custom_messages.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from lona.html import HTML, H2
 from lona.view import LonaView
+from lona.html import HTML, H2
 from lona._json import dumps
 
 

--- a/test_project/views/frontend/widget_data.py
+++ b/test_project/views/frontend/widget_data.py
@@ -1,4 +1,4 @@
-from lona.html import HTML, Div, H2, Br, Widget, Select, Strong
+from lona.html import Widget, Strong, Select, Div, Br, HTML, H2
 from lona.static_files import Script
 from lona.view import LonaView
 from lona._json import dumps

--- a/test_project/views/locking/html_tree_locking.py
+++ b/test_project/views/locking/html_tree_locking.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lona.html import Strong, Button, Span, Div, H2, Br
+from lona.html import Strong, Button, Span, Div, Br, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/locking/server_state_locking.py
+++ b/test_project/views/locking/server_state_locking.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lona.html import Strong, Button, Span, Div, H2, Br
+from lona.html import Strong, Button, Span, Div, Br, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/multi_user/multi_user_chat.py
+++ b/test_project/views/multi_user/multi_user_chat.py
@@ -1,4 +1,4 @@
-from lona.html import HTML, H1, H2, Div, TextArea, Button, Hr
+from lona.html import TextArea, Button, Div, Hr, HTML, H2, H1
 from lona.view import LonaView
 
 

--- a/test_project/views/response_types/http_redirect.py
+++ b/test_project/views/response_types/http_redirect.py
@@ -1,4 +1,4 @@
-from lona.html import Div, H2, P, Strong
+from lona.html import Strong, Div, P, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/response_types/redirect.py
+++ b/test_project/views/response_types/redirect.py
@@ -1,4 +1,4 @@
-from lona.html import Div, H2, P, Strong
+from lona.html import Strong, Div, P, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/view_types/async_view.py
+++ b/test_project/views/view_types/async_view.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from lona.html import HTML, Br, H2, Div, Button
+from lona.html import Button, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/view_types/daemonized_view.py
+++ b/test_project/views/view_types/daemonized_view.py
@@ -1,4 +1,4 @@
-from lona.html import Div, H2, Button
+from lona.html import Button, Div, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/view_types/form_view.py
+++ b/test_project/views/view_types/form_view.py
@@ -1,6 +1,6 @@
 from pprint import pformat
 
-from lona.html import HTML, H2, Br, Div, Pre, Form, TextInput, Button, Submit
+from lona.html import TextInput, Submit, Button, Form, Pre, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/view_types/http_pass_through_view.py
+++ b/test_project/views/view_types/http_pass_through_view.py
@@ -1,6 +1,6 @@
-from lona.view import LonaView
-
 from aiohttp.web import Response
+
+from lona.view import LonaView
 
 
 class HTTPPassThroughView(LonaView):

--- a/test_project/views/view_types/interactive_view.py
+++ b/test_project/views/view_types/interactive_view.py
@@ -1,4 +1,4 @@
-from lona.html import HTML, Div, Br, H2, Select, Strong
+from lona.html import Strong, Select, Div, Br, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_project/views/window_actions/set_title.py
+++ b/test_project/views/window_actions/set_title.py
@@ -1,4 +1,4 @@
-from lona.html import HTML, Div, H2, A
+from lona.html import Div, A, HTML, H2
 from lona.view import LonaView
 
 

--- a/test_script/test_script.py
+++ b/test_script/test_script.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from lona.html import HTML, H1, Div, A
-from lona import LonaApp, LonaView
+from lona.html import Div, A, HTML, H1
+from lona import LonaView, LonaApp
 
 app = LonaApp(__file__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from typing import Dict, Tuple
+from typing import Tuple, Dict
+
 import pytest
 
 # see https://docs.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps  # NOQA: E501

--- a/tests/test_0001_html.py
+++ b/tests/test_0001_html.py
@@ -5,14 +5,14 @@ import pytest
 from lona.html import (
     NumberInput,
     TextInput,
-    CheckBox,
     TextArea,
-    Button,
-    Select,
+    CheckBox,
     Submit,
-    HTML,
+    Select,
+    Button,
     Node,
     Div,
+    HTML,
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,11 @@ deps =
 commands =
     flake8 --config=flake8.ini lona tests test_project test_script doc
     mypy -p lona
+
+
+[testenv:isort]
+deps =
+    isort
+
+commands =
+    isort .

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,13 @@ deps =
     flake8-pytest-style
     flake8-quotes
     mypy
+    isort
 
 commands =
     flake8 --config=flake8.ini lona tests test_project test_script doc
     mypy -p lona
+    # we may use flake8-isort, but it is slow https://github.com/gforcada/flake8-isort/issues/101
+    isort --check-only .
 
 
 [testenv:isort]


### PR DESCRIPTION
* add `make isort`
* validate imports in linter
* can't use `flake8-isort` because of gforcada/flake8-isort#101