### PR TITLE
html: parsing: optional slash in self-closing tags

### DIFF
--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -120,7 +120,12 @@ class NodeHTMLParser(HTMLParser):
         # generic nodes
         return Node
 
-    def handle_starttag(self, tag, attrs):
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs, self_closing=True)
+
+    def handle_starttag(self, tag, attrs, self_closing=False):
+        self_closing = self_closing or tag in SELF_CLOSING_TAGS
+
         # node attributes
         node_attributes = {}
 
@@ -134,7 +139,7 @@ class NodeHTMLParser(HTMLParser):
         node_kwargs = {}
 
         node_kwargs['tag_name'] = tag
-        node_kwargs['self_closing_tag'] = tag in SELF_CLOSING_TAGS
+        node_kwargs['self_closing_tag'] = self_closing
 
         # setup node
         for key in ('id', 'class', 'style'):
@@ -149,7 +154,8 @@ class NodeHTMLParser(HTMLParser):
 
         # setup node
         self._node.append(node)
-        self.set_current_node(node)
+        if not self_closing:
+            self.set_current_node(node)
 
     def handle_data(self, data):
         text = data

--- a/tests/test_0001_html.py
+++ b/tests/test_0001_html.py
@@ -441,6 +441,30 @@ class TestHTMLFromStr:
         ):
             HTML('</span>')
 
+    def test_self_closing_tag_with_slash(self):
+        img = HTML('<div><img src="abc"/></div>')[0].nodes[0]
+
+        assert img.tag_name == 'img'
+        assert img.self_closing_tag is True
+
+    def test_self_closing_tag_without_slash(self):
+        img = HTML('<div><img src="abc"></div>')[0].nodes[0]
+
+        assert img.tag_name == 'img'
+        assert img.self_closing_tag is True
+
+    def test_non_self_closing_tag(self):
+        div = HTML('<div></div>')[0]
+
+        assert div.tag_name == 'div'
+        assert div.self_closing_tag is False
+
+    def test_non_self_closing_tag_with_slash(self):
+        span = HTML('<div><span/></div>')[0].nodes[0]
+
+        assert span.tag_name == 'span'
+        assert span.self_closing_tag is True
+
     def test_default_input_type_is_text(self):
         node = HTML('<input value="abc"/>')[0]
 


### PR DESCRIPTION
Before this change slash was not optional in self-closing tags.