### PR TITLE
lint: use flake8-length plugin

### DIFF
--- a/doc/plugins/changelog.py
+++ b/doc/plugins/changelog.py
@@ -22,7 +22,7 @@ class ChanglogHeader(Directive):
                         {date_string}
                         <a class="anchor" href="/changelog.html#{release_name}"></a>
                     </h2>
-                """,  # NOQA: E501
+                """,
                 format='html',
             ),
         ]

--- a/doc/plugins/pygments.py
+++ b/doc/plugins/pygments.py
@@ -1,4 +1,4 @@
-# source: https://github.com/pengutronix/flamingo/blob/master/flamingo/plugins/rst/pygments.py  # NOQA: E501
+# source: https://github.com/pengutronix/flamingo/blob/master/flamingo/plugins/rst/pygments.py
 
 from tempfile import TemporaryDirectory
 import os

--- a/doc/plugins/rst_setting.py
+++ b/doc/plugins/rst_setting.py
@@ -1,4 +1,4 @@
-# source: https://github.com/pengutronix/flamingo/blob/master/doc/plugins/rst_setting.py  # NOQA: E501
+# source: https://github.com/pengutronix/flamingo/blob/master/doc/plugins/rst_setting.py
 
 from docutils.parsers.rst import directives, Directive
 from flamingo.core.utils.imports import acquire

--- a/doc/plugins/toc_tree.py
+++ b/doc/plugins/toc_tree.py
@@ -11,7 +11,7 @@ TOC_TREE_TEMPLATE_STRING = """
         <li>{{ indentation * '&nbsp;&nbsp;&nbsp;&nbsp;' }}<a href="#{{ section .attrs['id'] }}">{{ header }}</a></li>
     {% endfor %}
 </ul>
-"""  # NOQA: E501
+"""  # NOQA: LN001
 
 _toc_tree_template = Template(TOC_TREE_TEMPLATE_STRING)
 
@@ -43,7 +43,7 @@ class TocTree:
             anchor = soup.new_tag('a')
             anchor.attrs['class'] = 'anchor'
 
-            anchor.attrs['href'] = f"/{content['output']}#{section.attrs['id']}"  # NOQA: E501
+            anchor.attrs['href'] = f"/{content['output']}#{section.attrs['id']}"
 
             header.append(anchor)
 

--- a/flake8.ini
+++ b/flake8.ini
@@ -4,6 +4,10 @@ extend-exclude =
     doc/env,
     test_project/env
 
+extend-ignore =
+    # because we use flake8-length
+    E501, W505
+
 show-source = true
 
 per-file-ignores =

--- a/lona/app.py
+++ b/lona/app.py
@@ -109,7 +109,7 @@ class LonaApp:
     def middleware(self, middleware_class: Type) -> None:
         ...
 
-    def middleware(self, middleware_class: Optional[Type] = None) -> Optional[Callable[[Type], None]]:  # NOQA: E501
+    def middleware(self, middleware_class: Optional[Type] = None) -> Optional[Callable[[Type], None]]:  # NOQA: LN001
         def decorator(middleware_class: Type) -> None:
             self.settings.MIDDLEWARES.append(middleware_class)
 
@@ -128,7 +128,7 @@ class LonaApp:
     def frontend_view(self, view_class: Type[LonaView]) -> None:
         ...
 
-    def frontend_view(self, view_class: Optional[Type[LonaView]] = None) -> Optional[Callable[[Type[LonaView]], None]]:  # NOQA: E501
+    def frontend_view(self, view_class: Optional[Type[LonaView]] = None) -> Optional[Callable[[Type[LonaView]], None]]:  # NOQA: LN001
         def decorator(view_class: Type[LonaView]) -> None:
             self.settings.FRONTEND_VIEW = view_class
 

--- a/lona/default_views.py
+++ b/lona/default_views.py
@@ -35,7 +35,7 @@ class FallbackView(LonaView):
 
             except Exception:
                 logger.exception(
-                    "exception raised while running '%s'. running fallback view",  # NOQA: E501
+                    "exception raised while running '%s'. running fallback view",
                     view_setting,
                 )
 

--- a/lona/html/attribute_dict.py
+++ b/lona/html/attribute_dict.py
@@ -76,12 +76,12 @@ class AttributeDict:
 
         if name in ('id', 'class'):
             raise RuntimeError(
-                f"Node.attributes['{name}'] is not supported. Use Node.{name}_list instead.",  # NOQA: E501
+                f"Node.attributes['{name}'] is not supported. Use Node.{name}_list instead.",
             )
 
         if name == 'style':
             raise RuntimeError(
-                f"Node.attributes['{name}'] is not supported. Use Node.{name} instead.",  # NOQA: E501
+                f"Node.attributes['{name}'] is not supported. Use Node.{name} instead.",
             )
 
         with self._node.lock:
@@ -134,12 +134,12 @@ class AttributeDict:
 
             if name in ('id', 'class'):
                 raise RuntimeError(
-                    f"Node.attributes['{name}'] is not supported. Use Node.{name}_list instead.",  # NOQA: E501
+                    f"Node.attributes['{name}'] is not supported. Use Node.{name}_list instead.",
                 )
 
             if name == 'style':
                 raise RuntimeError(
-                    f"Node.attributes['{name}'] is not supported. Use Node.{name} instead.",  # NOQA: E501
+                    f"Node.attributes['{name}'] is not supported. Use Node.{name} instead.",
                 )
 
         with self._node.lock:

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -52,7 +52,7 @@ def _find_node_classes(module):
 
                 if node_class.ATTRIBUTES['type'] in INPUT_NODE_CLASSES:
                     logger.warning(
-                        "WARNING: Two input Node classes with type '%s' were found: %r and %r",  # NOQA: E501
+                        "WARNING: Two input Node classes with type '%s' were found: %r and %r",
                         node_class.ATTRIBUTES['type'],
                         INPUT_NODE_CLASSES[node_class.ATTRIBUTES['type']],
                         node_class,
@@ -64,7 +64,7 @@ def _find_node_classes(module):
             else:
                 if node_class.TAG_NAME in NODE_CLASSES:
                     logger.warning(
-                        "WARNING: Two Node classes with tag name '%s' were found: %r and %r",  # NOQA: E501
+                        "WARNING: Two Node classes with tag name '%s' were found: %r and %r",
                         node_class.TAG_NAME,
                         NODE_CLASSES[node_class.TAG_NAME],
                         node_class,
@@ -175,7 +175,7 @@ class NodeHTMLParser(HTMLParser):
             )
         if tag != self._node.tag_name:
             raise ValueError(
-                f'Invalid html: </{self._node.tag_name}> expected, </{tag}> received',  # NOQA: E501
+                f'Invalid html: </{self._node.tag_name}> expected, </{tag}> received',
             )
 
         self.set_current_node(self._node.parent)

--- a/lona/html/selector.py
+++ b/lona/html/selector.py
@@ -1,6 +1,6 @@
 import re
 
-SELECTOR_RE = re.compile(r'([#.])?(([^#.\[\]]+)|(\[([^=\[\]]+)=([^=\[\]]+)\]))')  # NOQA: E501
+SELECTOR_RE = re.compile(r'([#.])?(([^#.\[\]]+)|(\[([^=\[\]]+)=([^=\[\]]+)\]))')
 UNSUPPORTED_CHARACTERS = re.compile(r'([ $|!~>+])')
 
 

--- a/lona/html/widget.py
+++ b/lona/html/widget.py
@@ -57,7 +57,7 @@ class Widget(AbstractNode):
 
     # string representation ###################################################
     def __str__(self):
-        return f'<!--lona-widget:{self.id}-->\n{self.nodes}\n<!--end-lona-widget:{self.id}-->'  # NOQA: E501
+        return f'<!--lona-widget:{self.id}-->\n{self.nodes}\n<!--end-lona-widget:{self.id}-->'
 
     def __repr__(self):
         return self.__str__()

--- a/lona/middleware_controller.py
+++ b/lona/middleware_controller.py
@@ -121,7 +121,7 @@ class MiddlewareController:
                 # is considered as handled
 
                 logger.debug(
-                    'data got handled by %s.%s by returning a custom value: %r',  # NOQA: E501
+                    'data got handled by %s.%s by returning a custom value: %r',
                     middleware,
                     hook_name,
                     return_value,

--- a/lona/response_parser.py
+++ b/lona/response_parser.py
@@ -50,7 +50,7 @@ class ResponseParser:
             # check keys
             if len(set(raw_response_dict) & key_words) != 1:
                 raise RuntimeError(
-                    'response dicts have to contain exactly one keyword of: {}'.format(  # NOQA: E501
+                    'response dicts have to contain exactly one keyword of: {}'.format(  # NOQA: LN001
                         ', '.join(key_words),
                     ),
                 )

--- a/lona/server.py
+++ b/lona/server.py
@@ -307,7 +307,7 @@ class LonaServer:
             text=response_dict['text'],
         )
 
-        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'  # NOQA: E501
+        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
 
         return response
 
@@ -321,7 +321,7 @@ class LonaServer:
 
         if not self.settings.STATIC_FILES_SERVE:
             server_logger.warning(
-                'Reverse proxy seems to be misconfigured: a static file request was received but STATIC_FILES_SERVE is disabled',  # NOQA: E501
+                'Reverse proxy seems to be misconfigured: a static file request was received but STATIC_FILES_SERVE is disabled',
             )
 
             return _404()
@@ -382,7 +382,7 @@ class LonaServer:
             if data:
                 if not isinstance(data, str):
                     raise RuntimeError(
-                        f'{middleware}.handle_connection returned non string data',  # NOQA: E501
+                        f'{middleware}.handle_connection returned non string data',
                     )
 
                 await connection.send_str(data, wait=False)

--- a/lona/settings.py
+++ b/lona/settings.py
@@ -14,7 +14,7 @@ class Settings:
     def add(self, path):
         if not path.endswith('.py'):
             logger.error(
-                "'%s' does not look like python script (modules are not supported)",  # NOQA: E501
+                "'%s' does not look like python script (modules are not supported)",
                 path,
             )
 

--- a/lona/shell/commands/lona_middlewares.py
+++ b/lona/shell/commands/lona_middlewares.py
@@ -38,7 +38,7 @@ class LonaMiddlewaresCommand:
 
             for middleware, _hook in middleware_controller.hooks[hook_name]:
                 self.repl.write(
-                    f'    {middleware.__module__}.{middleware.__class__.__name__}\n',  # NOQA: E501
+                    f'    {middleware.__module__}.{middleware.__class__.__name__}\n',
                 )
 
             self.repl.write('\n')

--- a/lona/view.py
+++ b/lona/view.py
@@ -273,11 +273,11 @@ class LonaView:
             self._view_runtime.state = VIEW_RUNTIME_STATE.RUNNING
 
     @overload
-    def await_input_event(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_input_event(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     @overload
-    def await_input_event(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_input_event(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     def await_input_event(self, *nodes, html=None):
@@ -288,11 +288,11 @@ class LonaView:
         )
 
     @overload
-    def await_click(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_click(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     @overload
-    def await_click(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_click(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     def await_click(self, *nodes, html=None):
@@ -303,11 +303,11 @@ class LonaView:
         )
 
     @overload
-    def await_change(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_change(self, *nodes: AbstractNode, html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     @overload
-    def await_change(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: E501
+    def await_change(self, __nodes: List[AbstractNode], html: _HTML = None) -> InputEvent:  # NOQA: LN001
         ...
 
     def await_change(self, *nodes, html=None):
@@ -355,13 +355,13 @@ class LonaView:
         embed_shell(server=self.server, locals=_locals)
 
     # hooks ###################################################################
-    def handle_request(self, request: Request) -> Union[None, str, AbstractNode, dict]:  # NOQA: E501
+    def handle_request(self, request: Request) -> Union[None, str, AbstractNode, dict]:  # NOQA: LN001
         return ''
 
-    def handle_input_event_root(self, input_event: InputEvent) -> Optional[InputEvent]:  # NOQA: E501
+    def handle_input_event_root(self, input_event: InputEvent) -> Optional[InputEvent]:  # NOQA: LN001
         return input_event
 
-    def handle_input_event(self, input_event: InputEvent) -> Optional[InputEvent]:  # NOQA: E501
+    def handle_input_event(self, input_event: InputEvent) -> Optional[InputEvent]:  # NOQA: LN001
         return input_event
 
     def on_shutdown(

--- a/lona/view_runtime.py
+++ b/lona/view_runtime.py
@@ -99,7 +99,7 @@ class ViewRuntime:
 
         self.document = Document()
 
-        self.stopped: asyncio.Future[Literal[True]] = asyncio.Future(loop=self.server.loop)  # NOQA: E501
+        self.stopped: asyncio.Future[Literal[True]] = asyncio.Future(loop=self.server.loop)  # NOQA: LN001
         self.is_stopped = False
         self.stop_reason = None
         self.is_daemon = False
@@ -290,7 +290,7 @@ class ViewRuntime:
                     'file' in raw_response_dict)):
 
                 raise RuntimeError(
-                    'JSON and file responses are only available in non-interactive mode',  # NOQA: E501
+                    'JSON and file responses are only available in non-interactive mode',
                 )
 
             return self.handle_raw_response_dict(raw_response_dict)
@@ -671,7 +671,7 @@ class ViewRuntime:
 
             # input event root handler
             input_events_logger.debug(
-                'runtime #%s: event #%s: running View.handle_input_event_root()',  # NOQA: E501
+                'runtime #%s: event #%s: running View.handle_input_event_root()',
                 self.view_runtime_id,
                 payload[0],
             )
@@ -707,7 +707,7 @@ class ViewRuntime:
 
                 if not nodes or input_event.node in nodes:
                     input_events_logger.debug(
-                        'runtime #%s: event #%s: is handled as pending %s event',  # NOQA: E501
+                        'runtime #%s: event #%s: is handled as pending %s event',
                         self.view_runtime_id,
                         payload[0],
                         input_event.name,
@@ -723,7 +723,7 @@ class ViewRuntime:
 
                 if not nodes or input_event.node in nodes:
                     input_events_logger.debug(
-                        'runtime #%s: event #%s: is handled as pending generic event',  # NOQA: E501
+                        'runtime #%s: event #%s: is handled as pending generic event',
                         self.view_runtime_id,
                         payload[0],
                     )

--- a/lona/view_runtime_controller.py
+++ b/lona/view_runtime_controller.py
@@ -96,7 +96,7 @@ class ViewRuntimeController:
 
         if connection.user != view_runtime.start_connection.user:
             input_events_logger.debug(
-                'event #%s: connection.user is not authorized. event is skipped',  # NOQA: E501
+                'event #%s: connection.user is not authorized. event is skipped',
                 payload[0],
             )
 
@@ -129,7 +129,7 @@ class ViewRuntimeController:
 
         if connection.user != view_runtime.start_connection.user:
             views_logger.debug(
-                'connection.user is not authorized. client error is skipped',  # NOQA: E501
+                'connection.user is not authorized. client error is skipped',
             )
 
             return

--- a/test_project/middlewares.py
+++ b/test_project/middlewares.py
@@ -35,7 +35,7 @@ class PermissionMiddleware:
 
         paths = (
             '/permissions/access-denied-in-PermissionMiddleware/',
-            '/permissions/access-denied-in-PermissionMiddleware/non-interactive/',  # NOQA: E501
+            '/permissions/access-denied-in-PermissionMiddleware/non-interactive/',
         )
 
         if request.url.path in paths:

--- a/test_project/routes.py
+++ b/test_project/routes.py
@@ -47,7 +47,7 @@ routes = [
     Route('/permissions/access-denied-in-PermissionMiddleware/',
           'views/permissions/denied_in_middleware.py::View'),
 
-    Route('/permissions/access-denied-in-PermissionMiddleware/non-interactive/',  # NOQA: E501
+    Route('/permissions/access-denied-in-PermissionMiddleware/non-interactive/',
           'views/permissions/denied_in_middleware.py::View',
           interactive=False),
 
@@ -68,7 +68,7 @@ routes = [
 
     Route(
         '/error-types/non-interactive-feature-error/',
-        'views/error_types/non_interactive_feature_error.py::NonInteractiveFeatureErrorView',  # NOQA: E501
+        'views/error_types/non_interactive_feature_error.py::NonInteractiveFeatureErrorView',
     ),
 
     # crashes

--- a/test_project/views/events/change_events.py
+++ b/test_project/views/events/change_events.py
@@ -46,5 +46,5 @@ class ChangeEventsView(LonaView):
             input_event = self.await_change(html=html)
 
             pre.set_text(
-                f'changed node: {input_event.node._id}\nvalue: {pformat(input_event.data)}',  # NOQA: E501
+                f'changed node: {input_event.node._id}\nvalue: {pformat(input_event.data)}',
             )

--- a/test_project/views/events/non_node_events.py
+++ b/test_project/views/events/non_node_events.py
@@ -9,7 +9,7 @@ class NonNodeEventView(LonaView):
             <button id="red-button" data-lona-events="301" style="color: white; background-color: red;">Red Button</button>
             <button id="green-button" data-lona-events="301" style="color: white; background-color: green;">Green Button</button>
 
-        """  # NOQA: E501
+        """  # NOQA: LN001
 
         message = 'No button pressed'
 

--- a/test_project/views/frontend/custom_messages.py
+++ b/test_project/views/frontend/custom_messages.py
@@ -23,7 +23,7 @@ class CustomMessagesView(LonaView):
 
             broadcast_message = dumps({
                 'notification': {
-                    'message': f'{datetime.now()}: This is a broadcast message',  # NOQA: E501
+                    'message': f'{datetime.now()}: This is a broadcast message',
                     'timeout': 2000,
                 },
             })

--- a/test_project/views/frontend/widget_data.py
+++ b/test_project/views/frontend/widget_data.py
@@ -38,7 +38,7 @@ class WidgetDataView(LonaView):
 
         html = HTML(
             H2('Widget Data'),
-            'This view tests the encoding and decoding of abstract widget data.',  # NOQA: E501
+            'This view tests the encoding and decoding of abstract widget data.',
             Br(),
             Br(),
             'The first value is the state the server has, the second is the '

--- a/test_project/views/home.py
+++ b/test_project/views/home.py
@@ -90,4 +90,4 @@ class HomeView(LonaView):
             <ul>
                 <li><a href="/multi-user/multi-user-chat/">Multi User Chat</a></li>
             </ul>
-        """  # NOQA: E501
+        """  # NOQA: LN001

--- a/test_script/test_script.py
+++ b/test_script/test_script.py
@@ -39,7 +39,7 @@ class Home(LonaView):
                 <li><a href="/interactive-view/">Interactive View</a></li>
                 <li><a href="/non-interactive-view/">Non Interactive View</a></li>
             </ul>
-        """  # NOQA: E501
+        """
 
 
 @app.route('/interactive-view/')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from typing import Tuple, Dict
 
 import pytest
 
-# see https://docs.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps  # NOQA: E501
+# see https://docs.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps
 
 # store history of failures per test class name
 # and per index in parametrize (if parametrize used)

--- a/tests/test_0001_html.py
+++ b/tests/test_0001_html.py
@@ -475,7 +475,7 @@ class TestHTMLFromStr:
             'password',
             'radio',
             'range',
-            'reset',  # intentionally, see 575dcf635180 ("html: remove Reset node")  # NOQA: E501
+            'reset',  # intentionally, see 575dcf635180 ("html: remove Reset node")  # NOQA: LN001
             'search',
             'tel',
             'time',
@@ -603,7 +603,7 @@ class TestNumberInput:
 
     def test_parsing_all_attributes(self):
         node = HTML(
-            '<input type="number" value="12.3" min="15.3" max="20.5" step="0.2"/>',  # NOQA: E501
+            '<input type="number" value="12.3" min="15.3" max="20.5" step="0.2"/>',
         )[0]
 
         assert node.value == 12.3

--- a/tests/test_0100_components.py
+++ b/tests/test_0100_components.py
@@ -11,35 +11,35 @@ import pytest
     'tests/test_0001_html.py::TestAttributeDict::test_non_empty_dict_is_true',
     'tests/test_0001_html.py::TestAttributeDict::test_pop_existing_key',
     'tests/test_0001_html.py::TestAttributeDict::test_pop_unknown_key',
-    'tests/test_0001_html.py::TestAttributeDict::test_pop_unknown_key_with_default',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeDict::test_pop_existing_key_with_default',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeDict::test_pop_expects_at_most_2_arguments',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_unknown_key_with_default',
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_existing_key_with_default',
+    'tests/test_0001_html.py::TestAttributeDict::test_pop_expects_at_most_2_arguments',
     'tests/test_0001_html.py::TestAttributeDict::test_del_existing_key',
     'tests/test_0001_html.py::TestAttributeDict::test_del_unknown_key',
-    'tests/test_0001_html.py::TestAttributeList::test_add_existing_element_does_nothing',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_add_existing_element_does_nothing',
     'tests/test_0001_html.py::TestAttributeList::test_add_one_element',
     'tests/test_0001_html.py::TestAttributeList::test_cant_add_dict',
     'tests/test_0001_html.py::TestAttributeList::test_cant_set_dict',
     'tests/test_0001_html.py::TestAttributeList::test_cant_set_list_with_dict',
     'tests/test_0001_html.py::TestAttributeList::test_clear',
     'tests/test_0001_html.py::TestAttributeList::test_clear_empty_list',
-    'tests/test_0001_html.py::TestAttributeList::test_default_class_list_is_empty',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeList::test_default_id_list_is_empty',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeList::test_default_list_has_zero_len',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_default_class_list_is_empty',
+    'tests/test_0001_html.py::TestAttributeList::test_default_id_list_is_empty',
+    'tests/test_0001_html.py::TestAttributeList::test_default_list_has_zero_len',
     'tests/test_0001_html.py::TestAttributeList::test_empty_list_is_false',
-    'tests/test_0001_html.py::TestAttributeList::test_equality_ignored_duplicates',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_equality_ignored_duplicates',
     'tests/test_0001_html.py::TestAttributeList::test_equality_ignores_order',
     'tests/test_0001_html.py::TestAttributeList::test_extend',
-    'tests/test_0001_html.py::TestAttributeList::test_extend_ignores_duplicates',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_extend_ignores_duplicates',
     'tests/test_0001_html.py::TestAttributeList::test_in_keyword',
-    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_list',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_passed_via_kwargs',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_space_separated_str',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_list',
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_passed_via_kwargs',
+    'tests/test_0001_html.py::TestAttributeList::test_initial_class_can_be_space_separated_str',
     'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_list',
-    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_passed_via_kwargs',  # NOQA: E501
-    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_space_separated_str',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_passed_via_kwargs',
+    'tests/test_0001_html.py::TestAttributeList::test_initial_id_can_be_space_separated_str',
     'tests/test_0001_html.py::TestAttributeList::test_initial_id_cant_be_dict',
-    'tests/test_0001_html.py::TestAttributeList::test_len_returns_number_of_elements',  # NOQA: E501
+    'tests/test_0001_html.py::TestAttributeList::test_len_returns_number_of_elements',
     'tests/test_0001_html.py::TestAttributeList::test_non_empty_list_is_true',
     'tests/test_0001_html.py::TestAttributeList::test_non_equality',
     'tests/test_0001_html.py::TestAttributeList::test_remove_existing_element',

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     flake8-bugbear
     flake8-commas
     flake8-comprehensions
+    flake8-length
     flake8-logging-format
     flake8-noqa
     flake8-pytest-style


### PR DESCRIPTION
[flake8-length](https://github.com/orsinium-labs/flake8-length) is less strict than default flake8 rules E501 and W505 about line length. Default for `max-line-length` option is still 79.