### PR TITLE
lint: use flake8-2020 plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands =
 [testenv:lint]
 deps =
     flake8
+    flake8-2020
     flake8-bugbear
     flake8-commas
     flake8-comprehensions


### PR DESCRIPTION
Let's use [flake8-2020](https://github.com/asottile/flake8-2020) to check for misuse of `sys.version` or `sys.version_info`. May be important after Python 3.10.