### PR TITLE
scripts: add command line args

### DIFF
--- a/lona/app.py
+++ b/lona/app.py
@@ -82,6 +82,7 @@ class LonaApp:
             http_pass_through: bool = False,
             frontend_view: Union[None, str, LonaView] = None,
     ) -> Callable[[Type[LonaView]], None]:
+
         def decorator(view_class: Type[LonaView]) -> None:
             self.routes.append(
                 Route(
@@ -96,6 +97,7 @@ class LonaApp:
 
         return decorator
 
+    # middleware
     @overload
     def middleware(self) -> Callable[[Type], None]:
         ...
@@ -110,11 +112,13 @@ class LonaApp:
 
         if callable(middleware_class):
             decorator(middleware_class)
+
             return None
 
         else:
             return decorator
 
+    # frontend
     @overload
     def frontend_view(self) -> Callable[[Type[LonaView]], None]:
         ...
@@ -129,6 +133,7 @@ class LonaApp:
 
         if callable(view_class):
             decorator(view_class)
+
             return None
 
         else:
@@ -142,6 +147,7 @@ class LonaApp:
             string: str = '',
             path: str = '',
     ) -> None:
+
         if name.startswith('/'):
             name = name[1:]
 
@@ -179,6 +185,7 @@ class LonaApp:
             string: str = '',
             path: str = '',
     ) -> None:
+
         return self._add_file(
             temp_dir=self.template_dir,
             name=name,
@@ -192,6 +199,7 @@ class LonaApp:
             string: str = '',
             path: str = '',
     ) -> None:
+
         return self._add_file(
             temp_dir=self.static_dir,
             name=name,

--- a/lona/app.py
+++ b/lona/app.py
@@ -1,5 +1,5 @@
 from typing import overload, Optional, Callable, Union, Type, List, Dict, Any
-from argparse import RawTextHelpFormatter, ArgumentParser
+from argparse import RawTextHelpFormatter, ArgumentParser, Namespace
 from tempfile import TemporaryDirectory
 from asyncio import AbstractEventLoop
 from os import PathLike
@@ -19,15 +19,6 @@ from lona.server import LonaServer
 from lona.routing import Route
 
 logger = logging.getLogger('lona.app')
-
-
-class ServerArgs:
-    def __init__(self, **args):
-        self.add(**args)
-
-    def add(self, **args):
-        for key, value in args.items():
-            setattr(self, key, value)
 
 
 class LonaApp:
@@ -337,7 +328,7 @@ class LonaApp:
     ) -> None:
 
         # setup arguments
-        server_args = ServerArgs(
+        server_args = Namespace(
             host='localhost',
             port=8080,
             shell_server_url='',
@@ -350,10 +341,14 @@ class LonaApp:
             settings_post_overrides=None,
         )
 
-        server_args.add(**args)
+        for key, value in args.items():
+            setattr(server_args, key, value)
 
         if parse_command_line:
-            server_args.add(**self.parse_command_line())
+            command_line_args = self.parse_command_line()
+
+            for key, value in command_line_args.items():
+                setattr(server_args, key, value)
 
         setup_logging(server_args)
 

--- a/lona/command_line/handle_command_line.py
+++ b/lona/command_line/handle_command_line.py
@@ -18,6 +18,25 @@ Code: https://github.com/lona-web-org/lona
 """.strip()
 
 
+def parse_overrides(raw_overrides):
+    environment = Environment()
+    overrides = {}
+
+    for override in raw_overrides:
+        if '=' not in override:
+            logger.error(
+                "settings overrides: invalid format: '%s'", override)
+
+            continue
+
+        name, value = override.split('=', 1)
+        value = environment.compile_expression(value)()
+
+        overrides[name] = value
+
+    return overrides
+
+
 def handle_command_line(argv):
     parser = ArgumentParser(
         prog='lona',
@@ -200,24 +219,6 @@ def handle_command_line(argv):
     # this can happen on python versions lower than 3.7
     if not args.command:
         exit('no sub command was given')
-
-    def parse_overrides(raw_overrides):
-        environment = Environment()
-        overrides = {}
-
-        for override in raw_overrides:
-            if '=' not in override:
-                logger.error(
-                    "settings overrides: invalid format: '%s'", override)
-
-                continue
-
-            name, value = override.split('=', 1)
-            value = environment.compile_expression(value)()
-
-            overrides[name] = value
-
-        return overrides
 
     args.settings_pre_overrides = parse_overrides(
         args.settings_pre_overrides,


### PR DESCRIPTION
With these patches command line arguments can be used in Lona scripts.

``python lona_script.py --port=8081 --shell -O Foo=True``