### PR TITLE
html: data binding: CheckBox: remove obsolete argument "input_delay"

### DIFF
--- a/lona/html/data_binding/inputs.py
+++ b/lona/html/data_binding/inputs.py
@@ -118,9 +118,9 @@ class CheckBox(TextInput):
     }
 
     def __init__(self, value=False, disabled=False, readonly=False,
-                 bubble_up=False, input_delay=0, **kwargs):
-        super().__init__(value, disabled, readonly,
-                         bubble_up, input_delay, **kwargs)
+                 bubble_up=False, **kwargs):
+
+        super().__init__(value, disabled, readonly, bubble_up, **kwargs)
 
     @property
     def value(self) -> bool:


### PR DESCRIPTION
input_delay makes only sense with text inputs.

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>