### PR TITLE
Add function `eventually()` for testing

### DIFF
--- a/lona/app.py
+++ b/lona/app.py
@@ -24,8 +24,8 @@ logger = logging.getLogger('lona.app')
 
 
 class LonaApp:
-    def __init__(self, script_path: PathLike) -> None:
-        self.script_path: PathLike = script_path
+    def __init__(self, script_path: PathLike | str) -> None:
+        self.script_path: PathLike | str = script_path
         self.project_root: str = os.path.dirname(self.script_path)
 
         self.aiohttp_app: None | Application = None


### PR DESCRIPTION
New function `eventually()` allows to wait for an expected state in tests. Iterator and context managers are used to be able repeating assertions.

Alternative approach is to accept function as an argument, and call it several times. But in this case user has to create a function inside test to make an assert. That's because `assert` is a statement and python doesn't allow it inside the `lambda`.