### PR TITLE
feat(tests): add lona_view_context pytest fixture

### DIFF
--- a/lona/pytest.py
+++ b/lona/pytest.py
@@ -54,6 +54,17 @@ def lona_app_context(request, aiohttp_client):
 
 
 @pytest.fixture()
+def lona_view_context(lona_app_context):
+    async def setup_lona_view_context(view_class):
+        def setup_app(app: LonaApp) -> None:
+            app.route('/')(view_class)
+
+        return await lona_app_context(setup_app)
+
+    return setup_lona_view_context
+
+
+@pytest.fixture()
 def lona_project_context(request, aiohttp_client):
     async def setup_lona_project_context(
         project_root: str = '',

--- a/tests/test_click_events.py
+++ b/tests/test_click_events.py
@@ -1,19 +1,17 @@
-def setup_app(app):
-    from lona.html import Button
-    from lona import LonaView
+from playwright.async_api import async_playwright
 
-    @app.route('/')
+from lona.html import Button
+from lona import LonaView
+
+
+async def test_rendering(lona_view_context):
     class MyLonaView(LonaView):
         def handle_request(self, request):
             self.show(Button('click me!'))
             self.await_click()
             self.show('SUCCESS')
 
-
-async def test_rendering(lona_app_context):
-    from playwright.async_api import async_playwright
-
-    context = await lona_app_context(setup_app)
+    context = await lona_view_context(MyLonaView)
 
     async with async_playwright() as p:
         browser = await p.chromium.launch()

--- a/tests/test_static_files_view.py
+++ b/tests/test_static_files_view.py
@@ -6,10 +6,9 @@ from lona.static_files import StyleSheet, Script
 from lona import LonaView
 
 
-def setup_app(app):
+async def test_static_files_view(lona_view_context):
     some_existing_file = os.path.basename(__file__)
 
-    @app.route('/')
     class MyLonaView(LonaView):
         STATIC_FILES = [
             StyleSheet(
@@ -39,9 +38,7 @@ def setup_app(app):
         def handle_request(self, request):
             return 'SUCCESS'
 
-
-async def test_static_files_view(lona_app_context):
-    context = await lona_app_context(setup_app)
+    context = await lona_view_context(MyLonaView)
 
     assert (await context.client.get('/static/view.css')).status == 200
     assert (await context.client.get('/static/view.js')).status == 200

--- a/tests/test_static_files_view.py
+++ b/tests/test_static_files_view.py
@@ -6,8 +6,8 @@ from lona.static_files import StyleSheet, Script
 from lona import LonaView
 
 
-async def test_static_files_view(lona_view_context):
-    some_existing_file = os.path.basename(__file__)
+async def test_static_files_view(request, lona_view_context):
+    some_existing_file = os.path.basename(request.fspath)
 
     class MyLonaView(LonaView):
         STATIC_FILES = [

--- a/tests/test_static_files_widget.py
+++ b/tests/test_static_files_widget.py
@@ -7,7 +7,7 @@ from lona.html import Widget
 from lona import LonaView
 
 
-def setup_app(app):
+async def test_static_files_widget(lona_view_context):
     some_existing_file = os.path.basename(__file__)
 
     class MyWidget(Widget):
@@ -36,14 +36,11 @@ def setup_app(app):
             ),
         ]
 
-    @app.route('/')
     class MyLonaView(LonaView):
         def handle_request(self, request):
             return 'SUCCESS'
 
-
-async def test_static_files_widget(lona_app_context):
-    context = await lona_app_context(setup_app)
+    context = await lona_view_context(MyLonaView)
 
     assert (await context.client.get('/static/widget.css')).status == 200
     assert (await context.client.get('/static/widget.js')).status == 200

--- a/tests/test_static_files_widget.py
+++ b/tests/test_static_files_widget.py
@@ -7,8 +7,8 @@ from lona.html import Widget
 from lona import LonaView
 
 
-async def test_static_files_widget(lona_view_context):
-    some_existing_file = os.path.basename(__file__)
+async def test_static_files_widget(request, lona_view_context):
+    some_existing_file = os.path.basename(request.fspath)
 
     class MyWidget(Widget):
         STATIC_FILES = [

--- a/tests/test_test_project.py
+++ b/tests/test_test_project.py
@@ -1,9 +1,9 @@
-async def test_test_project(lona_project_context):
+async def test_test_project(request, lona_project_context):
     import os
 
     from playwright.async_api import async_playwright
 
-    TEST_PROJECT_PATH = os.path.join(__file__, '../../test_project')
+    TEST_PROJECT_PATH = os.path.join(request.fspath, '../../test_project')
 
     context = await lona_project_context(
         project_root=TEST_PROJECT_PATH,


### PR DESCRIPTION
New `lona_view_context` pytest fixture allows not to create separate function `setup_app` in tests.

@fscherf I'm not sure we need this. What do you think?