### PR TITLE
fix(ci): lint: downgrade flake8-noqa

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     flake8-length
     flake8-logging-format
     flake8-mutable
-    flake8-noqa
+    flake8-noqa==1.1.0
     flake8-pytest-style
     flake8-quotes
     flake8-use-fstring


### PR DESCRIPTION
flake8-noqa 1.2.0 seems to have dependency resolving issues with
flake8-mutable. This results in a full freeze until the job gets killed by
GitHub.

From the pip log:

    INFO: pip is looking at multiple versions of flake8-noqa to determine which
    version is compatible with other requirements. This could take a while.

This patch downgrades flake8-noqa for now

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>