### PR TITLE
fix(views): fix handling of lona.exceptions.StopReason

### DIFF
--- a/lona/view_runtime.py
+++ b/lona/view_runtime.py
@@ -344,6 +344,10 @@ class ViewRuntime:
 
             return self.handle_raw_response_dict(raw_response_dict)
 
+        # view got stopped from outside
+        except(StopReason, CancelledError) as exception:
+            self.stop_reason = exception
+
         # 403 Forbidden
         except ForbiddenError as exception:
             self.stop_reason = exception


### PR DESCRIPTION
This broke in 885845e4e94533b952b79456fa67758a4f293fc7.

Because lona.exceptions.StopReason gets handled like every other exception,
Lona produces a error log line on every user disconnect, which makes no sense
and is confusing to end users.

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>