### PR TITLE
fix(views): fix cleanup of non-interactive view runtimes

### DIFF
--- a/lona/view_runtime_controller.py
+++ b/lona/view_runtime_controller.py
@@ -272,7 +272,14 @@ class ViewRuntimeController:
             )
 
         else:
-            return view_runtime.start()
+            response_dict = view_runtime.start()
+
+            # Non interactive runtimes don't have to be held in memory, after
+            # handle_request() finished, because they can't be daemonized or
+            # receive input events.
+            self.remove_view_runtime(view_runtime)
+
+            return response_dict
 
         views_logger.debug('message handled')
 


### PR DESCRIPTION
Previously non-interactive view runtimes never got removed from
ViewRuntimeController._view_runtimes properly. This becomes a problem when
combining non-interactive views and limiting concurrent users
(https://lona-web.org/cookbook/limit-concurrent-views.html)

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>