### PR TITLE
fix(html): widget data: fix patch generating

### DIFF
--- a/lona/html/widget_data.py
+++ b/lona/html/widget_data.py
@@ -149,7 +149,7 @@ class ListOverlay:
                 payload=[
                     self._key_path,
                     name,
-                    item,
+                    deepcopy(item),
                 ],
             )
 
@@ -290,7 +290,7 @@ class DictOverlay:
                     payload=[
                         self._key_path,
                         key,
-                        value,
+                        deepcopy(value),
                     ],
                 )
 
@@ -312,7 +312,7 @@ class DictOverlay:
                 payload=[
                     self._key_path,
                     name,
-                    item,
+                    deepcopy(item),
                 ],
             )
 


### PR DESCRIPTION
The payload of patches have to be full copies of the original values to prevent
changes to the payload after the patch got created.

Previously some patches contained the original list or dict. When the dict or
list changed, the patch payload changed implicitly.

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>