### PR TITLE
fix import errors on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U setuptools
-        pip install tox
+        pip install -r tests/REQUIREMENTS.lint.txt
 
     - name: Run Tox
       run: tox -e lint
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U setuptools
-        pip install tox codecov
+        pip install -r tests/REQUIREMENTS.test.txt
 
     - name: Run Tox
       # Run tox using the version of Python in `PATH`

--- a/REQUIREMENTS.packaging.txt
+++ b/REQUIREMENTS.packaging.txt
@@ -1,1 +1,5 @@
 twine
+aiohttp>=3,<4
+jinja2
+rlpython
+typing-extensions

--- a/lona/__init__.py
+++ b/lona/__init__.py
@@ -1,14 +1,8 @@
-try:
-    from .exceptions import *  # NOQA: F403
-    from .routing import MATCH_ALL, Route
-    from .errors import *  # NOQA: F403
-    from .view import LonaView
-    from .app import LonaApp
-
-except ImportError:
-    # this happens while packaging and can be ignored
-
-    pass
+from .exceptions import *  # NOQA: F403
+from .routing import MATCH_ALL, Route
+from .errors import *  # NOQA: F403
+from .view import LonaView
+from .app import LonaApp
 
 VERSION = (1, 8, 4)
 VERSION_STRING = '.'.join(str(i) for i in VERSION)

--- a/lona/logging.py
+++ b/lona/logging.py
@@ -3,7 +3,6 @@ from textwrap import indent
 import threading
 import datetime
 import logging
-import syslog
 import socket
 import os
 
@@ -11,6 +10,15 @@ from lona.command_line.terminal import (
     terminal_supports_colors,
     colors_are_enabled,
 )
+
+try:
+    # syslog is only on unix based systems available
+    import syslog
+
+    SYSLOG_IS_AVAILABLE = True
+
+except ImportError:
+    SYSLOG_IS_AVAILABLE = False
 
 
 def journald_is_running():
@@ -91,7 +99,7 @@ class LogFormatter(logging.Formatter):
     def __init__(self, *args, syslog_priorities=False, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.syslog_priorities = syslog_priorities
+        self.syslog_priorities = SYSLOG_IS_AVAILABLE and syslog_priorities
 
         self.colors_enabled = (
             terminal_supports_colors() and

--- a/tests/REQUIREMENTS.lint.txt
+++ b/tests/REQUIREMENTS.lint.txt
@@ -3,6 +3,8 @@ jinja2
 rlpython
 typing-extensions
 
+tox
+coverage
 flake8==3.9.2
 flake8-2020==1.6.0
 flake8-bugbear==21.9.2

--- a/tests/REQUIREMENTS.lint.txt
+++ b/tests/REQUIREMENTS.lint.txt
@@ -1,3 +1,8 @@
+aiohttp>=3,<4
+jinja2
+rlpython
+typing-extensions
+
 flake8==3.9.2
 flake8-2020==1.6.0
 flake8-bugbear==21.9.2

--- a/tests/REQUIREMENTS.test.txt
+++ b/tests/REQUIREMENTS.test.txt
@@ -1,3 +1,8 @@
+aiohttp>=3,<4
+jinja2
+rlpython
+typing-extensions
+
 coverage==6.1.2
 pytest==6.2.5
 pytest-aiohttp==0.3.0

--- a/tests/REQUIREMENTS.test.txt
+++ b/tests/REQUIREMENTS.test.txt
@@ -3,6 +3,7 @@ jinja2
 rlpython
 typing-extensions
 
+tox
 coverage==6.1.2
 pytest==6.2.5
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
Currently Lona has different dependencies for production, packaging, linting and testing. All import errors during these stages get ignored by a try except block in the Lona top level module. This worked ok until now, but it covers up real import errors in production.
This PR adds all dependencies to all environments and removes the code that ignores all import errors.