### PR TITLE
fix quoting in attribute dicts

### DIFF
--- a/lona/html/attribute_dict.py
+++ b/lona/html/attribute_dict.py
@@ -199,18 +199,18 @@ class AttributeDict:
                         string.append(key)
 
                 else:
-                    string.append(f'{key}="{value}"')
+                    string.append(f'{key}="{html.escape(value)}"')
 
-            return html.escape(' '.join(string))
+            return ' '.join(string)
 
     def to_sub_attribute_string(self):
         with self._node.lock:
             string = []
 
             for key, value in self._attributes.items():
-                string.append(f'{key}: {value}')
+                string.append(f'{key}: {html.escape(value)}')
 
-            return html.escape('; '.join(string))
+            return '; '.join(string)
 
     def __repr__(self):
         return f'<AttributeDict({self._attributes!r})>'


### PR DESCRIPTION
Previously HTML representations looked like that:

    <input data-lona-node-id="1" type=&quot;checkbox&quot; />

This was because the whole attribute string was quoted and not every attribute
value individually.

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>