### PR TITLE
logo: fix bleeding background

### DIFF
--- a/doc/content/logo.svg
+++ b/doc/content/logo.svg
@@ -12,8 +12,8 @@
    viewBox="0 0 200.00001 200"
    version="1.1"
    id="svg8"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
-   sodipodi:docname="lona.svg">
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="logo.svg">
   <title
      id="title904">lona logo</title>
   <defs
@@ -77,66 +77,66 @@
        transform="matrix(1.14322,0,0,1.14322,37.201289,-14.647313)"
        style="stroke-width:0.874722">
       <path
-         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:#d9a050;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -94.124234,86.971036 35.545838,103.232604 6.68687,3.6912 -35.60409,-103.401789 z"
          id="path1470"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:#e3be79;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -93.245997,50.468723 48.881771,141.962957 -7.5273,1.46316 -35.60409,-103.401789 -8.060178,-39.617047 z"
          id="path1472"
          sodipodi:nodetypes="cc" />
       <path
-         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:#d9a050;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -102.17666,47.22124 8.052427,39.749796 6.628617,3.522015 -8.060178,-39.617047 z"
          id="path1474"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:#e1a450;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -102.17666,47.22124 2.309803,-0.407278 6.620867,3.654762 -2.3098,0.407282 z"
          id="path1476"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:#e3be79;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -102.73552,52.141983 -32.76916,130.203417 7.39371,-1.30371 32.555178,-130.165687 z"
          id="path1478" />
       <path
-         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:#e1a450;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -109.35639,48.48722 7.17973,-1.26598 6.62087,3.654766 -7.17973,1.265977 z"
          id="path1480"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#d9a050;fill-opacity:1;fill-rule:evenodd;stroke:#d9a050;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -142.00601,178.75662 6.50133,3.58878 32.76916,-130.203417 -6.62087,-3.654763 z"
          id="path1482"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#dca75d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#dca75d;fill-opacity:1;fill-rule:evenodd;stroke:#dca75d;stroke-width:0.231437;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -112.90538,205.75473 8.03073,-153.235561 -6.46001,-3.683127 -8.03971,153.406888 z"
          id="path1484"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:#e3be79;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -98.812802,73.354441 -3.922718,-21.212457 -2.13913,0.377185 -8.03073,153.235561 7.2274,-1.40486 z"
          id="path1486"
          sodipodi:nodetypes="cccccc" />
       <path
-         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e1a450;fill-opacity:1;fill-rule:evenodd;stroke:#e1a450;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -104.87465,52.519169 -6.46001,-3.683127 1.97827,-0.348822 6.62087,3.654763 z"
          id="path1488"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#cfcfcf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#cfcfcf;fill-opacity:1;fill-rule:evenodd;stroke:#cfcfcf;stroke-width:0.231437;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -125.63953,169.61408 8.51299,-4.2777 -20.58604,-101.183597 -8.51296,4.27785 z"
          id="path1490"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#dcdcdc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#dcdcdc;fill-opacity:1;fill-rule:evenodd;stroke:#dcdcdc;stroke-width:0.231437;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -125.63953,169.61408 8.51299,-4.2777 82.412584,-14.53156 -8.51247,4.27761 z"
          id="path1492"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#eff0f2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#eff0f2;fill-opacity:1;fill-rule:evenodd;stroke:#eff0f2;stroke-width:0.231437;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -137.71188,64.152434 82.411844,-14.531432 20.58607,101.183828 -82.412574,14.53155 z"
          id="path1494"
          sodipodi:nodetypes="ccccc" />
@@ -144,38 +144,38 @@
          aria-label="LONA"
          transform="matrix(0.97738935,-0.17591973,0.21517477,0.98440454,0,0)"
          id="text1498"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;line-height:1.25;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-color:#000000;letter-spacing:-0.16677px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#393939;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.43736;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;line-height:1.25;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-color:#000000;letter-spacing:-0.16677px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#393939;fill-opacity:1;fill-rule:evenodd;stroke:#50e159;stroke-width:0.231437;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:transform-center-x="2.1281722"
          inkscape:transform-center-y="0.97494637">
         <path
            d="m -126.56235,87.463461 q -0.12408,0.201638 -0.2947,0.325723 -0.17062,0.124086 -0.37225,0.201639 -1.10126,0.589404 -2.26456,0.992681 -1.1633,0.387766 -2.34211,0.697979 -1.16329,0.279192 -2.35761,0.465319 -1.17881,0.170618 -2.35762,0.09306 -0.58941,-0.04653 -1.07024,-0.310213 -0.48083,-0.263681 -0.85308,-0.666957 -0.37226,-0.403277 -0.63594,-0.915128 -0.26368,-0.511852 -0.41879,-1.023703 -0.35674,-1.054724 -0.48083,-2.17149 -0.10857,-1.132277 -0.031,-2.280065 0.0776,-1.706171 0.29471,-3.396831 0.23265,-1.706171 0.55838,-3.427853 0.23266,-0.837574 0.40328,-1.706171 0.18612,-0.884106 0.41878,-1.69066 0.24817,-0.806553 0.63594,-1.520043 0.38777,-0.71349 1.05472,-1.225341 0.31022,-0.06204 0.55839,0.03102 0.24817,0.09306 0.40327,0.294703 0.17062,0.201638 0.23266,0.48083 0.062,0.26368 0.0155,0.542872 -0.062,0.96166 -0.13959,1.907809 -0.0776,0.94615 -0.20164,1.90781 -0.0776,0.775532 -0.18613,1.535554 -0.10857,0.74451 -0.20164,1.535553 -0.10857,0.775533 -0.17061,1.551065 -0.062,0.760021 -0.12409,1.551064 -0.0155,0.71349 -0.062,1.473512 -0.031,0.760021 0.0155,1.504532 0.0465,0.729 0.23266,1.426979 0.18613,0.682469 0.63593,1.256363 0.99269,-0.06204 1.96986,-0.23266 0.99268,-0.186128 1.96985,-0.434298 0.79104,-0.170617 1.53555,-0.356745 0.74451,-0.186128 1.53556,-0.24817 0.69798,-0.01551 1.24085,0.403277 0.55838,0.403276 0.79104,1.023702 0.031,0.108575 0.062,0.201638 0.031,0.09306 0,0.201639 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.437362"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.231437;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path906" />
         <path
            d="m -110.07068,78.699947 q -0.17062,1.876788 -0.68247,3.722554 -0.49634,1.830256 -1.52005,3.520917 -0.43429,0.822064 -1.03921,1.628617 -0.60491,0.806554 -1.34942,1.44249 -0.74452,0.620426 -1.62862,1.008192 -0.88411,0.372256 -1.86128,0.341234 -0.94615,0.01551 -1.73719,-0.341234 -0.79104,-0.356745 -1.42698,-0.946149 -0.63594,-0.604915 -1.10126,-1.364937 -0.46532,-0.760021 -0.76002,-1.551064 -0.69798,-1.613107 -0.93064,-3.381321 -0.21715,-1.768213 -0.0155,-3.551938 0.15511,-1.659638 0.68247,-3.288256 0.54287,-1.628618 1.53555,-3.040087 0.48083,-0.713489 1.10126,-1.333915 0.63594,-0.620426 1.36494,-1.070235 0.74451,-0.449808 1.56657,-0.682468 0.82207,-0.24817 1.65964,-0.201638 0.80655,-0.01551 1.56658,0.201638 0.76002,0.201639 1.41146,0.620426 0.65145,0.403277 1.17881,0.977171 0.52737,0.573893 0.8686,1.271872 0.74451,1.349427 0.97717,2.900491 0.23266,1.535554 0.1396,3.11764 z m -3.52092,-1.411469 q 0.062,-0.760022 0,-1.489022 -0.062,-0.744511 -0.32572,-1.44249 -0.0931,-0.341234 -0.29471,-0.651447 -0.18612,-0.310213 -0.46532,-0.542873 -0.26368,-0.232659 -0.60491,-0.356744 -0.34123,-0.139596 -0.71349,-0.139596 -0.60492,-0.04653 -1.1633,0.170617 -0.54287,0.217149 -1.0237,0.589404 -0.46532,0.372256 -0.83758,0.868596 -0.37225,0.48083 -0.60491,1.008192 -0.55838,1.101256 -0.85309,2.280065 -0.2947,1.178809 -0.38776,2.357618 -0.10858,0.992681 -0.062,1.985363 0.062,0.97717 0.24817,1.93883 0.0931,0.418788 0.21714,0.884107 0.1396,0.449809 0.35675,0.853085 0.23266,0.387767 0.55838,0.682469 0.34124,0.279191 0.85309,0.325723 0.74451,-0.01551 1.3184,-0.372255 0.58941,-0.356745 1.03922,-0.899617 0.4498,-0.542873 0.79104,-1.19432 0.34123,-0.651447 0.60491,-1.240852 0.49634,-1.380447 0.88411,-2.776405 0.38777,-1.395958 0.46532,-2.838448 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.437362"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.231437;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path908" />
         <path
            d="m -93.796172,86.874056 q -0.108575,0.449809 -0.263681,0.899618 -0.139596,0.434298 -0.356745,0.853085 -0.217149,0.403277 -0.573894,0.760022 -0.341234,0.356745 -0.791043,0.434298 -0.853085,-0.03102 -1.473511,-0.449809 -0.604915,-0.418787 -1.070234,-1.023702 -0.46532,-0.604916 -0.837575,-1.302895 -0.356745,-0.697979 -0.729001,-1.302894 -0.791044,-1.628617 -1.551064,-3.210703 -0.74451,-1.582086 -1.47351,-3.226214 -0.32572,0.294702 -0.51185,0.666957 -0.18613,0.372256 -0.2947,0.791043 -0.0931,0.403277 -0.15511,0.822065 -0.0465,0.418787 -0.0931,0.822064 -0.062,0.651447 -0.062,1.302894 0.0155,0.651447 0.0155,1.318405 -0.062,0.651447 -0.0465,1.302894 0.031,0.635936 -0.0155,1.287383 -0.0465,0.310213 -0.062,0.71349 -0.0155,0.403277 -0.10858,0.775532 -0.0931,0.372256 -0.31021,0.635937 -0.20164,0.263681 -0.62043,0.310213 -0.32572,-0.03102 -0.63593,-0.155107 -0.31021,-0.139596 -0.51185,-0.372255 -0.1396,-0.279192 -0.29471,-0.558384 -0.13959,-0.294702 -0.17061,-0.635936 -0.38777,-1.44249 -0.4343,-2.947023 -0.031,-1.520043 0.031,-3.040086 0.031,-0.542872 0.0776,-1.054724 0.062,-0.511851 0.1396,-1.054724 0.12408,-1.20983 0.31021,-2.388639 0.18613,-1.178809 0.41879,-2.388639 0.23266,-0.806554 0.40328,-1.597597 0.17061,-0.791042 0.38776,-1.504532 0.23266,-0.729 0.55839,-1.349426 0.32572,-0.620426 0.8841,-1.070235 0.54288,-0.01551 0.94615,0.23266 0.40328,0.23266 0.69798,0.620426 0.31021,0.372255 0.54287,0.837575 0.24817,0.449808 0.48083,0.853085 0.58941,1.473511 1.13228,2.947023 0.558384,1.473511 1.116767,2.978043 0.23266,0.604915 0.46532,1.225341 0.232659,0.604915 0.48083,1.19432 0.263681,0.589404 0.573893,1.147788 0.325724,0.558383 0.729001,1.070234 0.201638,-0.496341 0.294702,-1.023702 0.09306,-0.527362 0.155106,-1.070235 0.06204,-1.023702 0.07755,-2.016384 0.01551,-0.992681 -0.01551,-1.985362 -0.03102,-0.977171 -0.03102,-1.92332 0.01551,-0.96166 0.04653,-1.938831 0.04653,-0.387766 0.09306,-0.899617 0.06204,-0.511852 0.217149,-0.96166 0.155106,-0.46532 0.465319,-0.775532 0.310213,-0.325724 0.853085,-0.325724 0.573894,0.09306 0.96166,0.434298 0.387767,0.341234 0.604916,0.837575 0.217149,0.48083 0.279191,1.054724 0.07755,0.558383 0.03102,1.085745 0,0.760021 -0.04653,1.504532 -0.03102,0.729001 -0.09306,1.489022 l -0.186128,3.086619 q -0.139596,1.737192 -0.310213,3.443363 -0.155106,1.706171 -0.325724,3.443363 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.437362"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.231437;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path910" />
         <path
            d="m -75.862016,88.905951 q -0.06204,0.403277 -0.372256,0.697979 -0.310213,0.279191 -0.71349,0.341234 -0.217149,0.01551 -0.434298,0.03102 -0.217149,0 -0.434298,-0.03102 -0.201638,-0.04653 -0.387766,-0.139596 -0.170617,-0.09306 -0.279191,-0.279191 -0.217149,-0.387766 -0.279192,-0.822065 -0.04653,-0.434298 -0.124085,-0.868596 -0.06204,-0.558383 -0.139596,-1.132277 -0.06204,-0.573894 -0.139596,-1.132277 -0.341234,-0.155106 -0.713489,-0.24817 -0.372256,-0.09306 -0.744511,-0.06204 -0.822065,0.03102 -1.613107,0.108575 -0.775533,0.06204 -1.566576,0.232659 -0.729,0.124086 -1.442489,0.356745 -0.697979,0.23266 -1.333916,0.682469 -0.387766,0.449808 -0.527362,1.008192 -0.124085,0.558383 -0.24817,1.101255 0,0.23266 -0.09306,0.48083 -0.09306,0.23266 -0.263681,0.418788 -0.155106,0.186128 -0.387766,0.294702 -0.23266,0.09306 -0.496341,0.04653 -0.48083,-0.09306 -0.822064,-0.372256 -0.325723,-0.294702 -0.527362,-0.713489 -0.527362,-0.760022 -0.527362,-1.69066 0.03102,-0.915128 0.325724,-1.799235 0.294702,-0.884107 0.697979,-1.737192 0.418787,-0.96166 0.853085,-1.938831 0.434298,-0.977171 0.930639,-1.907809 0.449809,-1.504533 0.96166,-2.962534 0.527362,-1.458 1.039213,-2.931511 0.294702,-0.604916 0.589405,-1.287384 0.310213,-0.682468 0.697979,-1.302894 0.387766,-0.620426 0.899617,-1.101256 0.527362,-0.48083 1.240852,-0.651447 0.651447,-0.03102 1.225341,0.263681 0.589404,0.279192 1.039213,0.682468 0.449808,0.449809 0.791043,0.977171 0.356744,0.527362 0.558383,1.147788 0.217149,0.604915 0.325723,1.240851 0.124086,0.620426 0.263681,1.271873 0.542873,2.528235 1.023703,5.04096 0.496341,2.512724 0.853085,5.087491 0.07755,0.449809 0.155107,0.868596 0.09306,0.418788 0.170617,0.853086 0.03102,0.449809 0.06204,0.899617 0.03102,0.449809 -0.09306,0.899618 z m -4.606662,-8.251663 q -0.01551,-0.899618 -0.155106,-1.768214 -0.124085,-0.868596 -0.325724,-1.721681 -0.201638,-0.853086 -0.449809,-1.690661 -0.232659,-0.837574 -0.449808,-1.675149 -0.71349,0.697979 -1.209831,1.566575 -0.48083,0.868596 -0.853085,1.768213 -0.372255,0.930639 -0.682468,1.892299 -0.310213,0.946149 -0.372256,1.92332 l -0.03102,0.201638 0.03102,0.186128 q -0.03102,0.124085 -0.04653,0.23266 0,0.09306 -0.06204,0.217149 l 0.04653,0.170617 q 0.263681,0 0.511851,0.01551 0.263681,0 0.527362,0 0.279191,0.04653 0.558383,0.06204 0.279192,0 0.558383,0 0.341234,0.03102 0.744511,-0.01551 0.403277,-0.04653 0.760022,-0.201639 0.356745,-0.170617 0.604915,-0.449809 0.24817,-0.279191 0.294702,-0.713489 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.437362"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.7658px;font-family:'Action Man';-inkscape-font-specification:'Action Man, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#393939;fill-opacity:1;stroke:none;stroke-width:0.231437;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path912" />
       </g>
       <path
-         style="display:inline;fill:#9d681e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#9d681e;fill-opacity:1;fill-rule:evenodd;stroke:#9d681e;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -49.583516,166.85783 -64.905074,11.44451 5.69034,-1.99627 64.906244,-11.44473 z"
          id="path1504"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#c78c39;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#c78c39;fill-opacity:1;fill-rule:evenodd;stroke:#c78c39;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -116.5812,168.01685 2.09261,10.28549 5.69034,-1.99627 -2.09493,-10.29695 z"
          id="path1506"
          sodipodi:nodetypes="ccccc" />
       <path
-         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.437361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         style="display:inline;fill:#e3be79;fill-opacity:1;fill-rule:evenodd;stroke:#e3be79;stroke-width:0.231437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -43.892016,164.86135 -2.09491,-10.29695 -64.906254,11.44472 2.09493,10.29695 z"
          id="path1508" />
     </g>


### PR DESCRIPTION
Some SVG renderers have bugs when two areas are right next to each other, and render each area on their own with antialiasing in relation to the background color. This has the disadvantageous effect that the background color bleeds through to the foreground, which in our case is mostly visible on dark backgrounds.

To fix this, add a 1px outline with the same color as the fill color to each of those areas, so that neighboring areas effectively overlap with each other, thereby covering the background.

Compare screenshots in Firefox before:
![0657a25a-828a-11ec-a686-507b9d024c54](https://user-images.githubusercontent.com/192014/151789566-cb4ca280-d9b5-42fb-b13c-904758319d01.png)

and after:
![f0ed8a5a-828a-11ec-b9b5-507b9d024c54](https://user-images.githubusercontent.com/192014/151789582-c1495040-5054-484b-b3d5-ded894b7b170.png)
