### PR TITLE
ci(pytest): cleanup tox.ini and pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,8 @@
 addopts= tests -v -rsx --tb=long --strict-markers
 markers =
     incremental: marks test class to stop execution after the first test method failed
-log_cli=false
-log_level=NOTSET
+log_cli= false
+log_level= NOTSET
 log_format = %(levelname)-8s %(name)-30s [%(asctime)s.%(msecs)03d] %(message)s
 log_date_format = %H:%M:%S
 automark_dependency = True

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,7 @@ commands =
 
     coverage run -a \
         -m pytest {tty:--color=yes} \
-            --junitxml {toxworkdir}{/}junit.{envname}.xml \
-            {posargs:tests}
+            --junitxml {toxworkdir}{/}junit.{envname}.xml
 
     coverage report
     coverage xml


### PR DESCRIPTION
Previously the test root directory was configured both in the tox.ini and the
pytest.ini.
This patch moves the configuration into the pytest.ini and fixes some
whitespaces too.

Signed-off-by: Florian Scherf <mail@florianscherf.de>