### PR TITLE
cleanup templating

### DIFF
--- a/lona/templating.py
+++ b/lona/templating.py
@@ -24,6 +24,14 @@ class Namespace:
     def reverse(self):
         return self.server.reverse
 
+    @property
+    def settings(self):
+        return self.server.settings
+
+    @property
+    def state(self):
+        return self.server.state
+
     def load_stylesheets(self):
         return self.server._static_file_loader.style_tags_html
 

--- a/lona/templating.py
+++ b/lona/templating.py
@@ -20,6 +20,10 @@ class Namespace:
         self.server = server
         self.templating_engine = templating_engine
 
+    @property
+    def reverse(self):
+        return self.server.reverse
+
     def load_stylesheets(self):
         return self.server._static_file_loader.style_tags_html
 
@@ -28,9 +32,6 @@ class Namespace:
 
     def _import(self, *args, **kwargs):
         return self.server.acquire(*args, **kwargs)
-
-    def resolve_url(self, *args, **kwargs):
-        return self.server._router.reverse(*args, **kwargs)
 
     def load_static_file(self, path):
         logger.debug('resolving static file path %s', path)


### PR DESCRIPTION
This PR brings some cleanup for the Lona namespace in Jinja2 templates, and some new shortcuts