### PR TITLE
server: Allow loading of state in settings

### DIFF
--- a/doc/content/cookbook/using-server-state.rst
+++ b/doc/content/cookbook/using-server-state.rst
@@ -21,3 +21,12 @@ accesses in a transaction, ``server.state.lock`` can be used explicit.
                 self.server.state['bar'] = 'bar'
 
             print(self.server.state['foo'])
+
+The ``server.state`` can be initialized in the settings using ``INITIAL_SERVER_STATE``:
+
+.. code-block:: python
+
+    # settings.py
+    INITITAL_SERVER_STATE = {
+        "myvalue": 42,
+    }

--- a/doc/content/end-user-documentation/settings.rst
+++ b/doc/content/end-user-documentation/settings.rst
@@ -170,6 +170,13 @@ Views
     :name: FRONTEND_VIEW
     :path: lona.default_settings.FRONTEND_VIEW
 
+.. setting::
+    :name: INITIAL_SERVER_STATE
+    :path: lona.default_settings.INITIAL_SERVER_STATE
+
+    This dict, if present, is copied to ``server.state``.
+    This is a convenient way to define or load server state on startup without
+    the need to write a specific middleware.
 
 Error Views
 -----------

--- a/lona/default_settings.py
+++ b/lona/default_settings.py
@@ -57,6 +57,7 @@ SESSIONS_KEY_RANDOM_LENGTH = 28
 # views
 CORE_FRONTEND_VIEW = 'lona.default_views.FrontendView'
 FRONTEND_VIEW = ''
+INITIAL_SERVER_STATE: dict = {}
 
 # error views
 CORE_ERROR_403_VIEW = 'lona.default_views.Error403View'

--- a/lona/server.py
+++ b/lona/server.py
@@ -4,6 +4,7 @@ from typing import overload, Callable, TypeVar, cast, Any
 from concurrent.futures import Future
 from collections.abc import Awaitable
 from functools import reduce
+from copy import deepcopy
 import contextlib
 import operator
 import logging
@@ -102,8 +103,9 @@ class LonaServer:
 
         # setup state
         server_logger.debug('setup state')
-
-        self._state = State(initial_data={})
+        self._state = State(
+            initial_data=deepcopy(self.settings.INITIAL_SERVER_STATE),
+        )
 
         # setup routing
         server_logger.debug('setup routing')


### PR DESCRIPTION
Until now there was no way to fill ``server.state`` before the first actual view has been initialized.

With this changes it is now possible to define or load the initial values for ``server.state`` in the ``settings.py``.

In my case I have a rather simple web application that keeps track of a queue of images.
One view shows this queue of images ("frontend") and another view allows to configure this queue ("backend").
Both views share the current queue using ``server.state``. But: I did not find an elegant way to load my initial state:
I could do it in ``handle_request`` but this would mean code duplication between the views.

For me the best way to handle this is to allow the user to define the *initial_state* of the ``server.state``.
And since I can run arbitrary python-magic in ``settings.py``this seems a perfect fit.