### PR TITLE
fix(HTML): Document: fix incorrect usage of Document.apply

### DIFF
--- a/lona/html/document.py
+++ b/lona/html/document.py
@@ -50,7 +50,7 @@ class Document:
 
     def serialize(self):
         if not self.html:
-            return self.apply('')
+            return self.apply(html='')
 
         # HTML string
         if isinstance(self.html, str):

--- a/lona/view_runtime.py
+++ b/lona/view_runtime.py
@@ -665,7 +665,7 @@ class ViewRuntime:
         def send_html_patches():
             with self.document.lock:
                 title, data_type, data = self.document.apply(
-                    self.document.html,
+                    html=self.document.html,
                 )
 
                 if data_type and data:


### PR DESCRIPTION
This patch fixes a bug, introduced in

    ff7a0ab8316c ("fix(views): fix page titles on daemonized views")

ff7a0ab8316c introduced a new, optional argument to Document.apply, named
'title' and broke all code that calls Document.apply without named arguments.

Signed-off-by: Florian Scherf <mail@florianscherf.de>