### PR TITLE
feat(server/routing): Add support for trailing wildcards

### DIFF
--- a/doc/content/end-user-documentation/views.rst
+++ b/doc/content/end-user-documentation/views.rst
@@ -157,6 +157,22 @@ Trailing Slashes
     ]
 
 
+Wildcards
+~~~~~~~~~
+
+Wildcards allow to glob the end of a route.
+
+.. code-block:: python
+
+    # routes.py
+
+    from lona import Route
+
+    routes = [
+        Route('/foo(*)', 'views/my_view.py::MyView'),
+    ]
+
+
 Request Objects
 ---------------
 

--- a/lona/routing.py
+++ b/lona/routing.py
@@ -8,6 +8,7 @@ ABSTRACT_ROUTE_RE = re.compile(r'<(?P<name>[^:>]+)(:(?P<pattern>[^>]+))?>')
 ROUTE_PART_FORMAT_STRING = r'(?P<{}>{})'
 DEFAULT_PATTERN = r'[^/]+'
 OPTIONAL_TRAILING_SLASH_PATTERN = r'(/)'
+TRAILING_WILDCARD_PATTERN = r'(*)'
 
 MATCH_ALL = 1
 
@@ -28,6 +29,7 @@ class Route:
         self.path = None
         self.format_string = ''
         self.optional_trailing_slash = False
+        self.trailing_wildcard = False
 
         # match all
         if self.raw_pattern == MATCH_ALL:
@@ -39,9 +41,13 @@ class Route:
 
             if raw_pattern.endswith(OPTIONAL_TRAILING_SLASH_PATTERN):
                 self.optional_trailing_slash = True
-
                 raw_pattern = \
                     raw_pattern[:-len(OPTIONAL_TRAILING_SLASH_PATTERN)]
+
+            if raw_pattern.endswith(TRAILING_WILDCARD_PATTERN):
+                self.trailing_wildcard = True
+                raw_pattern = \
+                    raw_pattern[:-len(TRAILING_WILDCARD_PATTERN)]
 
             groups = ABSTRACT_ROUTE_RE.findall(raw_pattern)
 
@@ -81,6 +87,9 @@ class Route:
         if self.path:
             if self.optional_trailing_slash and path.endswith('/'):
                 path = path[:-1]
+
+            if self.trailing_wildcard:
+                path = path[:min(len(path), len(self.path))]
 
             return path == self.path, {}
 


### PR DESCRIPTION
This change adds support for wildcard routes.
Wildcards can only be used at the end of a route.

A wildcard can be used to Route all URLs beginning with a
given path to a view or a Django application.

Consider the following example for the Django Admin:
The easy way to route the Django Admin is to have a fallback route at
the end of the routing table.
But this is not possible if there is another route that matches the
URL.

In this case a wildcard match can be used:

```
routes = [
    # (...)

    # More specific match
    Route('/admin(*)', wsgi_handler, http_pass_through=True),

    # Broad match
    Route('/<output>(/)', 'views/home.py::HomeView'),
]
```