### PR TITLE
fix(shell): fix incompatibility with rlpython 0.10

### DIFF
--- a/lona/command_line/run_server.py
+++ b/lona/command_line/run_server.py
@@ -55,7 +55,7 @@ def run_server(args, app=None, server=None):
         async def start_shell(server):
             def _start_shell():
                 embed_kwargs = {
-                    'locals': {
+                    'globals': {
                         'loop': loop,
                         'server': server,
                         'cli_args': vars(args),
@@ -104,7 +104,7 @@ def run_server(args, app=None, server=None):
     if args.shell_server_url:
         embed_kwargs = {
             'bind': args.shell_server_url,
-            'locals': {
+            'globals': {
                 'loop': loop,
                 'server': server,
                 'cli_args': vars(args),

--- a/lona/shell/commands/lona_connections.py
+++ b/lona/shell/commands/lona_connections.py
@@ -19,7 +19,7 @@ class LonaConnectionsCommand:
 
         argument_parser.parse_args(argv[1:])
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # write connections
         rows = [['User', 'URL']]

--- a/lona/shell/commands/lona_info.py
+++ b/lona/shell/commands/lona_info.py
@@ -26,11 +26,11 @@ class LonaInfoCommand:
         rows = [
             ['Key', 'Value'],
             ['Lona version', f'v{VERSION_STRING}'],
-            ['project root', self.repl.locals['server'].project_root],
-            ['cli args', pformat(self.repl.locals.get('cli_args', {}))],
+            ['project root', self.repl.globals['server'].project_root],
+            ['cli args', pformat(self.repl.globals.get('cli_args', {}))],
 
             ['logging syslog priorities',
-             repr(self.repl.locals['log_formatter'].syslog_priorities)],
+             repr(self.repl.globals['log_formatter'].syslog_priorities)],
         ]
 
         write_table(rows, self.repl.write)

--- a/lona/shell/commands/lona_middlewares.py
+++ b/lona/shell/commands/lona_middlewares.py
@@ -21,7 +21,7 @@ class LonaMiddlewaresCommand:
 
         argument_parser.parse_args(argv[1:])
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
         middleware_controller = server._middleware_controller
 
         # list middlewares

--- a/lona/shell/commands/lona_routes.py
+++ b/lona/shell/commands/lona_routes.py
@@ -25,7 +25,7 @@ class LonaRoutesCommand:
 
         arguments = vars(argument_parser.parse_args(argv[1:]))
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # resolve
         if arguments['resolve']:

--- a/lona/shell/commands/lona_server_state.py
+++ b/lona/shell/commands/lona_server_state.py
@@ -21,7 +21,7 @@ class LonaServerStateCommand:
 
         argument_parser.parse_args(argv[1:])
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # write table
         rows = [['Key', 'Value']]

--- a/lona/shell/commands/lona_settings.py
+++ b/lona/shell/commands/lona_settings.py
@@ -15,7 +15,7 @@ class LonaSettingsCommand:
         self.repl = repl
 
     def complete(self, text, state, line_buffer):
-        names = sorted(self.repl.locals['server'].settings)
+        names = sorted(self.repl.globals['server'].settings)
         candidates = []
 
         for name in names:
@@ -37,7 +37,7 @@ class LonaSettingsCommand:
 
         arguments = vars(argument_parser.parse_args(argv[1:]))
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # write setting
         if arguments['name']:

--- a/lona/shell/commands/lona_static_files.py
+++ b/lona/shell/commands/lona_static_files.py
@@ -36,7 +36,7 @@ class LonaStaticFilesCommand:
 
         args = argument_parser.parse_args(argv[1:])
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # resolve
         if args.resolve:

--- a/lona/shell/commands/lona_templates.py
+++ b/lona/shell/commands/lona_templates.py
@@ -37,7 +37,7 @@ class LonaTemplatesCommand:
 
         args = argument_parser.parse_args(argv[1:])
 
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
 
         # resolve
         if args.resolve:

--- a/lona/shell/commands/lona_views.py
+++ b/lona/shell/commands/lona_views.py
@@ -24,7 +24,7 @@ class LonaViewsCommand:
         self.repl = repl
 
     def complete(self, text, state, line_buffer):
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
         controller = server._view_runtime_controller
 
         view_runtime_ids = []
@@ -124,7 +124,7 @@ class LonaViewsCommand:
         return self.list_views(arguments)
 
     def show_view_memory(self, arguments):
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
         controller = server._view_runtime_controller
 
         if not arguments['runtime-id']:
@@ -168,7 +168,7 @@ class LonaViewsCommand:
             self.repl.write('\n\n')
 
     def show_view_info(self, arguments):
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
         controller = server._view_runtime_controller
 
         try:
@@ -262,7 +262,7 @@ class LonaViewsCommand:
         self.repl.write('\n')
 
     def list_views(self, arguments):
-        server = self.repl.locals['server']
+        server = self.repl.globals['server']
         controller = server._view_runtime_controller
 
         rows = [


### PR DESCRIPTION
rlpython version prior to 0.10 had separate globals and locals. 0.10 merged
them into a global namespace named globals.

This patch changes all code that reads or writes repl.locals.

Signed-off-by: Florian Scherf <mail@florianscherf.de>