### PR TITLE
fix(doc): Show that custom URL-pattern can match any character

### DIFF
--- a/doc/content/end-user-documentation/views.rst
+++ b/doc/content/end-user-documentation/views.rst
@@ -132,6 +132,8 @@ Simple Patterns
 Custom Patterns
 ~~~~~~~~~~~~~~~
 
+Custom patterns can be any valid regex:
+
 .. code-block:: python
 
     # routes.py
@@ -140,6 +142,19 @@ Custom Patterns
 
     routes = [
         Route('/<arg1:[a-z]{3}>/', 'views/my_view.py::MyView'),
+    ]
+
+It is possible to match any character (including the ``/``).
+The following route matches any URL beginning with ``prefix``:
+
+.. code-block:: python
+
+    # routes.py
+
+    from lona import Route
+
+    routes = [
+        Route('/prefix<path:.*>', 'views/my_view.py::MyView'),
     ]
 
 


### PR DESCRIPTION
In https://github.com/lona-web-org/lona/pull/223 I showed that I did not
understand that a custom pattern can be used to create a wildcard match.

This change updates the documentation to contain some more words about
custom patterns.

Signed-off-by: Chris Fiege <chris@tinyhost.de>