### PR TITLE
feat(TemplatingEngine): Allow to set-up jinja environment

### DIFF
--- a/lona/templating.py
+++ b/lona/templating.py
@@ -76,8 +76,11 @@ class Namespace:
 
 
 class TemplatingEngine:
-    def __init__(self, server):
+    def __init__(self, server, jinja_environment_kwargs=None):
         self.server = server
+
+        if not jinja_environment_kwargs:
+            jinja_environment_kwargs = {}
 
         self.template_dirs = (self.server.settings.TEMPLATE_DIRS +
                               self.server.settings.CORE_TEMPLATE_DIRS)
@@ -96,6 +99,7 @@ class TemplatingEngine:
                 self.template_dirs,
                 followlinks=True,
             ),
+            **jinja_environment_kwargs,
         )
 
         # load extra filters


### PR DESCRIPTION
This change allows a user to create an own TemplatingEngine with a
custom set-up Jinja2-Environment.

The lona default TemplatingEnine uses Jinja2 with default paramenters.
This is fine if uses inside lona to render HTML for the client.

For applications where templates are rendered for other languages, e.g.
Latex, the default settings may be in the way.
With this change a user can create their own instance of TemplatingEninge
with specific settings, e.g. overriding ``block_start_string`` and still
have the filters and paths available as set up in the settings.

Useage example:
```
engine = lona.templating.TemplatingEngine(
    server,
    jinja_environment_kwargs={
        'block_start_string': r'<%',
        'block_end_string': r'%>',
        'variable_start_string': r'<<',
        'variable_end_string': r'>>',
    },
)

content = engine.render_template(
    template_name,
)
```