### PR TITLE
fix(html): Make sure value is a str()

### DIFF
--- a/lona/html/attribute_dict.py
+++ b/lona/html/attribute_dict.py
@@ -199,7 +199,7 @@ class AttributeDict:
                         string.append(key)
 
                 else:
-                    string.append(f'{key}="{html.escape(value)}"')
+                    string.append(f'{key}="{html.escape(str(value))}"')
 
             return ' '.join(string)
 
@@ -208,7 +208,7 @@ class AttributeDict:
             string = []
 
             for key, value in self._attributes.items():
-                string.append(f'{key}: {html.escape(value)}')
+                string.append(f'{key}: {html.escape(str(value))}')
 
             return '; '.join(string)
 


### PR DESCRIPTION
``html.escape()`` assumes that ``value`` is a string (or some type it
can call ``.replace()`` on.
This fails for most other types than string.

Without this fix the following code breaks:
```
from lona.html import Option
op = Option('Text', value='text', bubble_up=True)
print(op)
```

```
LonaRuntimeWorker_0            ERROR    16:37:32.446884 lona.view_runtime Exception raised while running <__main__.MyView object at 0x7fba87f8a790>
  Traceback (most recent call last):
    File "/home/chris/work/Projects/intern/lag-intranet/env/lib/python3.9/site-packages/lona/view_runtime.py", line 318, in start
      raw_response_dict = self.view.handle_request(self.request) or ''
    File "/home/chris/work/Projects/intern/lag-intranet/demo.py", line 11, in handle_request
      print(op)
    File "/home/chris/work/Projects/intern/lag-intranet/env/lib/python3.9/site-packages/lona/html/node.py", line 312, in __str__
      string += self.attributes.to_attribute_string(
    File "/home/chris/work/Projects/intern/lag-intranet/env/lib/python3.9/site-packages/lona/html/attribute_dict.py", line 202, in to_attribute_string
      string.append(f'{key}="{html.escape(value)}"')
    File "/usr/lib/python3.9/html/__init__.py", line 19, in escape
      s = s.replace("&", "&amp;") # Must be done first!
  AttributeError: 'bool' object has no attribute 'replace'
```

This change makes sure that every value passed is casted to string and
thus does not crash.

(This does not prevent the user from setting ``bubble_up`` on a node
that does not support event bubbling. But at least it does not fail.)