### PR TITLE
Fix `dependabot.yml` to work with dev deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,14 @@ version: 2
 
 updates:
 - package-ecosystem: pip
-  directory: "./tests/REQUIREMENTS.lint.txt"
+  directory: "./tests/"
   schedule:
     interval: daily
     time: "02:00"
   open-pull-requests-limit: 10
 
 - package-ecosystem: pip
-  directory: "./tests/REQUIREMENTS.test.txt"
+  directory: "."
   schedule:
     interval: daily
     time: "02:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,14 @@ version: 2
 
 updates:
 - package-ecosystem: pip
-  directory: "/tests/REQUIREMENTS.lint.txt"
+  directory: "./tests/REQUIREMENTS.lint.txt"
   schedule:
     interval: daily
     time: "02:00"
   open-pull-requests-limit: 10
 
 - package-ecosystem: pip
-  directory: "/tests/REQUIREMENTS.test.txt"
+  directory: "./tests/REQUIREMENTS.test.txt"
   schedule:
     interval: daily
     time: "02:00"


### PR DESCRIPTION
As you can see, your dependecies are not updated.
Dependabot expects relative paths, not absolute ones.