### PR TITLE
html: make widgets obsolete

### DIFF
--- a/doc/content/end-user-documentation/html.rst
+++ b/doc/content/end-user-documentation/html.rst
@@ -819,12 +819,13 @@ handle the event.
 Frontend Widgets
 ~~~~~~~~~~~~~~~~
 
-Widgets can define a Javascript based frontend widget, to include client side
-code. This is useful to integrate with third party Javascript libraries.
+Widgets and nodes can define a Javascript based frontend widget, to include
+client side code. This is useful to integrate with third party Javascript
+libraries.
 
 To communicate between the backend widget and the frontend widget, the backend
-can set its state in ``Widget.state``, a dict like object, and the frontend
-can issue events with custom data.
+can set its state in ``Widget.state``, or in ``Node.widget_data`` a dict like
+object, and the frontend can issue events with custom data.
 
 .. code-block:: python
 
@@ -847,6 +848,31 @@ can issue events with custom data.
             ]
 
             self.data = {'foo': 'bar'}
+
+
+.. code-block:: python
+
+    # my_node.py
+
+    from lona.static_files import Script
+    from lona.html import Div
+
+    class MyNode(Div):
+        WIDGET = 'MyFrontendWidget'
+
+        STATIC_FILES = [
+            # the path is always relative to the current file
+            Script(name='MyFrontendWidget', path='my_frontend_widget.js'),
+        ]
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            self.nodes = [
+                Div('foo'),
+            ]
+
+            self.widget_data = {'foo': 'bar'}
 
 
 .. code-block:: javascript

--- a/lona/client/_lona/dom-renderer.js
+++ b/lona/client/_lona/dom-renderer.js
@@ -48,6 +48,8 @@ export class LonaDomRenderer {
             var node_style = node_spec[5];
             var node_attributes = node_spec[6];
             var node_child_nodes = node_spec[7];
+            var widget_class_name = node_spec[8];
+            var widget_data = node_spec[9];
 
             var node = document.createElement(node_tag_name);
 
@@ -105,6 +107,27 @@ export class LonaDomRenderer {
 
             this.lona_window._nodes[node_id] = node;
             node_list.push(node);
+
+            // widget
+            if(widget_class_name != '') {
+                if(!(widget_class_name in Lona.widget_classes)) {
+                    throw(`RuntimeError: unknown widget name '${widget_class_name}'`);
+                }
+
+                var widget_class = Lona.widget_classes[widget_class_name];
+
+                var window_shim = new LonaWindowShim(
+                    this.lona_context,
+                    this.lona_window,
+                    node_id,
+                );
+
+                var widget = new widget_class(window_shim);
+
+                this.lona_window._widgets[node_id] = widget;
+                this.lona_window._widget_data[node_id] = widget_data;
+                this.lona_window._widgets_to_setup.splice(0, 0, node_id);
+            }
 
         // TextNode
         } else if(node_type == Lona.protocol.NODE_TYPE.TEXT_NODE) {

--- a/lona/client/_lona/dom-updater.js
+++ b/lona/client/_lona/dom-updater.js
@@ -47,6 +47,10 @@ export class LonaDomUpdater {
     };
 
     _get_widget_nodes(node_id) {
+        if(node_id in this.lona_window._nodes) {
+            return [this.lona_window._nodes[node_id]];
+        }
+
         var node_list = [];
         var widget_marker = this.lona_window._widget_marker[node_id];
         var end_marker_text = 'end-lona-widget:' + node_id;

--- a/lona/client/_lona/window.js
+++ b/lona/client/_lona/window.js
@@ -198,6 +198,7 @@ export class LonaWindow {
             };
 
             widget.nodes = this._dom_updater._get_widget_nodes(node_id);
+            widget.root_node = widget.nodes[0];
 
             if(widget.setup !== undefined) {
                 widget.setup();

--- a/lona/html/node.py
+++ b/lona/html/node.py
@@ -8,6 +8,7 @@ from lona.html.attribute_list import ClassList, IDList
 from lona.html.node_event_list import NodeEventList
 from lona.events import ChangeEventType, EventType
 from lona.html.abstract_node import AbstractNode
+from lona.html.widget_data import WidgetData
 from lona.html.node_list import NodeList
 from lona.protocol import NODE_TYPE
 
@@ -37,14 +38,25 @@ class Node(AbstractNode):
     STYLE: dict[str, str] | str = {}
     ATTRIBUTES: dict[str, str] = {}
     EVENTS: list[EventType | ChangeEventType] = []
+    WIDGET: str = ''
 
-    def __init__(self, *args, tag_name=None, self_closing_tag=None, **kwargs):
+    def __init__(
+            self,
+            *args,
+            tag_name=None,
+            self_closing_tag=None,
+            widget='',
+            **kwargs,
+    ):
+
         self._id_list = IDList(self, self.ID_LIST)
         self._class_list = ClassList(self, self.CLASS_LIST)
         self._style = StyleDict(self, self.STYLE)
         self._attributes = AttributeDict(self, self.ATTRIBUTES)
         self._nodes = NodeList(self)
         self._events = NodeEventList(self, self.EVENTS)
+        self._widget = widget or self.WIDGET
+        self._widget_data = WidgetData(widget=self)
 
         # tag overrides
         self.tag_name = tag_name or self.TAG_NAME
@@ -216,6 +228,15 @@ class Node(AbstractNode):
     def nodes(self, value):
         self._nodes._reset(value)
 
+    # widget_data
+    @property
+    def widget_data(self):
+        return self._widget_data
+
+    @widget_data.setter
+    def widget_data(self, value):
+        self._widget_data._reset(value)
+
     # lona attribute helper ###################################################
     def has_class(self, class_name):
         return class_name in self._class_list
@@ -241,6 +262,11 @@ class Node(AbstractNode):
 
     # serialization ###########################################################
     def _serialize(self):
+        widget_data = None
+
+        if self._widget:
+            widget_data = self._widget_data._serialize()
+
         return [
             NODE_TYPE.NODE,
             self.id,
@@ -250,6 +276,8 @@ class Node(AbstractNode):
             self._style._serialize(),
             self._attributes._serialize(),
             self._nodes._serialize(),
+            self._widget,
+            widget_data,
         ]
 
     # node list helper ########################################################

--- a/tests/static/test-widget.js
+++ b/tests/static/test-widget.js
@@ -1,0 +1,19 @@
+class TestWidget {
+    constructor(lona_window) {
+        this.lona_window = lona_window;
+    };
+
+    _dump_data() {
+        this.root_node.innerHTML = JSON.stringify(this.data);
+    };
+
+    setup() {
+        this._dump_data();
+    };
+
+    data_updated() {
+        this._dump_data();
+    };
+};
+
+Lona.register_widget_class('test-widget', TestWidget);

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,122 @@
+import json
+
+from playwright.async_api import async_playwright
+
+from lona.html import Button, HTML, Div
+from lona.static_files import Script
+from lona.pytest import eventually
+from lona._json import dumps
+from lona import LonaView
+
+
+async def test_widgets(lona_app_context):
+    state = {
+        'test-node': None,
+        'done': False,
+    }
+
+    def setup_app(app):
+
+        class TestNode(Div):
+            ID_LIST = ['test-node']
+
+            STATIC_FILES = [
+                Script(
+                    name='test-widget',
+                    path='static/test-widget.js',
+                ),
+            ]
+
+            WIDGET = 'test-widget'
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+                self.widget_data = {}
+
+        @app.route('/')
+        class TestView(LonaView):
+            def handle_request(self, request):
+                test_node = TestNode()
+
+                html = HTML(
+                    test_node,
+                    Button('Update', _id='update'),
+                )
+
+                state['test-node'] = test_node
+
+                # list
+                test_node.widget_data = {'list': []}
+
+                for i in range(6):
+                    test_node.widget_data['list'].append(i)
+                    self.await_input_event(html=html)
+
+                test_node.widget_data['list'].remove(2)
+                self.await_input_event(html=html)
+
+                test_node.widget_data['list'].insert(2, 2)
+                self.await_input_event(html=html)
+
+                test_node.widget_data['list'].clear()
+                self.await_input_event(html=html)
+
+                test_node.widget_data['list'] = [5, 4, 3, 2, 1]
+                self.await_input_event(html=html)
+
+                # dict
+                test_node.widget_data = [{}]
+
+                for i in range(6):
+                    test_node.widget_data[0][i] = i
+                    self.await_input_event(html=html)
+
+                test_node.widget_data[0].pop(2)
+                self.await_input_event(html=html)
+
+                test_node.widget_data[0].clear()
+                self.await_input_event(html=html)
+
+                test_node.widget_data[0] = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
+                self.await_input_event(html=html)
+
+                # done
+                state['done'] = True
+
+    context = await lona_app_context(setup_app)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        browser_context = await browser.new_context()
+        page = await browser_context.new_page()
+
+        await page.goto(context.make_url())
+
+        async def run_test():
+            for _ in range(100):
+                for attempt in eventually():
+                    async with attempt:
+
+                        # check if view is done
+                        if state['done']:
+                            return
+
+                        # server side widget data
+                        server_side_widget_data = json.loads(
+                            dumps(state['test-node'].widget_data),
+                        )
+
+                        # client side widget data
+                        node = await page.query_selector('#test-node')
+                        inner_html = await node.inner_html()
+
+                        client_side_widget_data = json.loads(inner_html)
+
+                        # check
+                        assert (server_side_widget_data ==
+                                client_side_widget_data)
+
+                await page.click('#update')
+
+        await run_test()


### PR DESCRIPTION
Like discussed in https://github.com/lona-web-org/lona/discussions/228, this PR adds all features of `lona.html.Widget` into `lona.html.Node`, to make widgets obsolete, so they can be removed in Lona 2