### PR TITLE
fix(collect_static): LonaServer does not need `app` anymore

### DIFF
--- a/lona/command_line/collect_static.py
+++ b/lona/command_line/collect_static.py
@@ -2,8 +2,6 @@ import contextlib
 import shutil
 import os
 
-from aiohttp.web import Application
-
 from lona.logging import setup_logging
 from lona.server import LonaServer
 
@@ -59,7 +57,6 @@ def collect_static(args):
 
     # setup server
     server = LonaServer(
-        app=Application(),
         project_root=args.project_root,
         settings_paths=args.settings,
         settings_pre_overrides=args.settings_pre_overrides,

--- a/lona/static_file_loader.py
+++ b/lona/static_file_loader.py
@@ -241,3 +241,19 @@ class StaticFileLoader:
         logger.debug("'%s' was not found", path)
 
         return None
+
+    def get_paths(self) -> Iterator[tuple[str, str]]:
+
+        # copy node static files
+        for static_file in self.static_files[::-1]:
+            if not static_file.enabled:
+                continue
+
+            yield static_file.path, static_file.url
+
+        # static directories
+        for static_dir in self.static_dirs[::-1]:
+            for name in os.listdir(static_dir):
+                path = os.path.join(static_dir, name)
+
+                yield path, name

--- a/test_project/routes.py
+++ b/test_project/routes.py
@@ -137,6 +137,9 @@ routes = [
           'views/window_actions/set_title.py::WindowTitleView'),
 
     # frontend
+    Route('/frontend/static-files/',
+          'views/frontend/static_files.py::StaticFilesView'),
+
     Route('/frontend/widget-data/',
           'views/frontend/widget_data.py::WidgetDataView'),
 

--- a/test_project/views/frontend/node-styles.css
+++ b/test_project/views/frontend/node-styles.css
@@ -1,0 +1,3 @@
+.blue-p {
+    color: blue;
+}

--- a/test_project/views/frontend/static_files.py
+++ b/test_project/views/frontend/static_files.py
@@ -1,0 +1,39 @@
+from lona.static_files import StyleSheet
+from lona.html import HTML, H2, P
+from lona.view import LonaView
+
+
+class BlueP(P):
+    CLASS_LIST = [
+        'blue-p',
+    ]
+
+    STATIC_FILES = [
+        StyleSheet(
+            name='node-styles',
+            path='node-styles.css',
+        ),
+    ]
+
+
+class StaticFilesView(LonaView):
+    STATIC_FILES = [
+        StyleSheet(
+            name='view-styles',
+            path='view-styles.css',
+        ),
+    ]
+
+    def handle_request(self, request):
+        return HTML(
+            H2('Static Files'),
+            P(
+                'This view tests the delivery of static files that are '
+                'defined in Nodes.STACIC_FILES or LonaView.STATIC_FILES',
+            ),
+            BlueP('This paragraph should be blue due node-styles.css'),
+            P(
+                'This paragraph should be blue due view-styles.css',
+                _class='red-p',
+            ),
+        )

--- a/test_project/views/frontend/view-styles.css
+++ b/test_project/views/frontend/view-styles.css
@@ -1,0 +1,3 @@
+.red-p {
+    color: red;
+}

--- a/test_project/views/home.py
+++ b/test_project/views/home.py
@@ -83,6 +83,7 @@ class HomeView(LonaView):
 
             <h2>Frontend</h2>
             <ul>
+                <li><a href="/frontend/static-files/">Static Files</a></li>
                 <li><a href="/frontend/widget-data/">Widget Data</a></li>
                 <li><a href="/frontend/custom-event/">Custom Event</a></li>
                 <li><a href="/frontend/custom-messages/">Custom Messages</a></li>

--- a/tests/test_collect_static.py
+++ b/tests/test_collect_static.py
@@ -1,0 +1,144 @@
+from tempfile import TemporaryDirectory
+from argparse import Namespace
+import os
+
+TEST_PROJECT_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '../test_project',
+)
+
+
+def _generate_command_line_args(
+        destination: str,
+        clean: bool = False,
+) -> Namespace:
+
+    return Namespace(
+
+        # basic configuration
+        project_root=TEST_PROJECT_PATH,
+        settings=['settings.py'],
+        settings_pre_overrides=[],
+        settings_post_overrides=[],
+        debug_mode='',
+        log_level='info',
+        loggers=[],
+        syslog_priorities='auto',
+
+        # collect-static specific arguments
+        destination=destination,
+        clean=clean,
+        silent=False,
+        dry_run=False,
+    )
+
+
+def _check_javascript_client_src_files(destination: str) -> None:
+    import lona
+
+    CLIENT_ROOT = os.path.join(
+        os.path.dirname(lona.__file__),
+        'client/_lona',
+    )
+
+    for client_src_file in os.listdir(CLIENT_ROOT):
+        abs_path = os.path.join(destination, '_lona/', client_src_file)
+
+        # check existence
+        assert os.path.exists(abs_path)
+
+        # check content
+        original = open(os.path.join(CLIENT_ROOT, client_src_file), 'r').read()
+        copy = open(abs_path, 'r').read()
+
+        assert copy == original
+
+
+def _check_test_project_static_files(destination: str):
+
+    # files in test_project/static
+    static_root = os.path.join(TEST_PROJECT_PATH, 'static')
+
+    for static_file in os.listdir(static_root):
+        abs_path = os.path.join(destination, static_file)
+
+        # check existence
+        assert os.path.exists(abs_path)
+
+        # check content
+        original = open(os.path.join(static_root, static_file), 'r').read()
+        copy = open(abs_path, 'r').read()
+
+        assert copy == original
+
+    # files defined in LonaView.STATIC_FILES and AbstractNode.STATIC_FILES
+    static_files = [
+
+        # contains: (original_path, copy_path, )
+        (os.path.join(TEST_PROJECT_PATH, 'views/frontend/node-styles.css'),
+         os.path.join(destination, 'node-styles.css')),
+        (os.path.join(TEST_PROJECT_PATH, 'views/frontend/view-styles.css'),
+         os.path.join(destination, 'view-styles.css')),
+    ]
+
+    for original_path, copy_path in static_files:
+
+        # check existence
+        assert os.path.exists(copy_path)
+
+        # check content
+        original = open(original_path, 'r').read()
+        copy = open(copy_path, 'r').read()
+
+        assert copy == original
+
+
+# tests #######################################################################
+def test_basic_collect_static():
+    from lona.command_line.collect_static import collect_static
+
+    with TemporaryDirectory() as tmp_dir:
+        args = _generate_command_line_args(
+            destination=tmp_dir,
+        )
+
+        collect_static(args=args)
+
+        _check_javascript_client_src_files(destination=tmp_dir)
+        _check_test_project_static_files(destination=tmp_dir)
+
+
+def test_non_empty_destinations():
+    from lona.command_line.collect_static import collect_static
+
+    with TemporaryDirectory() as tmp_dir:
+
+        # create a file so the destination is not empty
+        test_file_path = os.path.join(tmp_dir, 'foo.txt')
+
+        with open(test_file_path, 'w+') as f:
+            f.write('foo')
+
+        # first run
+        args = _generate_command_line_args(
+            destination=tmp_dir,
+            clean=False,
+        )
+
+        collect_static(args=args)
+
+        assert os.path.exists(test_file_path)
+        _check_javascript_client_src_files(destination=tmp_dir)
+        _check_test_project_static_files(destination=tmp_dir)
+
+        # second run
+        args = _generate_command_line_args(
+            destination=tmp_dir,
+            clean=True,
+        )
+
+        collect_static(args=args)
+
+        assert not os.path.exists(test_file_path)
+        _check_javascript_client_src_files(destination=tmp_dir)
+        _check_test_project_static_files(destination=tmp_dir)


### PR DESCRIPTION
This fixes a regression introduced in fe7edb65a89994ee767ea9c8f290d3ef147ff0c6.
This commit removes the `app` argument for the LonaServer(). Instead the aiohttp application is now provided inside the LonaServer (respecting the client_max_size setting.
Modules depending on the app can access is from inside the LonaServer.

This change, however, has not been reflected in the `collect-static` command line action.

Since collect static does not use the app we can simply remove the parameter.