### PR TITLE
html: select: refactor API

### DIFF
--- a/doc/content/end-user-documentation/html.rst
+++ b/doc/content/end-user-documentation/html.rst
@@ -633,40 +633,66 @@ Select
 
 .. code-block:: python
 
-    from lona.html import Select
+    from lona.html import Select, Option
 
-    Select(
-        values=[
-            # value, label, is_selected
-            ('foo', 'Foo', True),
-            ('bar', 'Bar', False),
-        ],
+    select = Select(
+        Option('Option 1', value='1'),
+        Option('Option 2', value=2),
+        Option('Option 3', value=3.0, selected=True),
     )
 
-**Init Arguments:**
+    # disable first option
+    select.options[0].disabled = True
+
+    # select second option by selected property
+    select.options[1].selected = True
+
+    # select second option by value property
+    select.value = 2
+
+A ``Select`` consist of one or more ``Option`` objects, which hold information
+on value, selection state and disabled state.
+
+``Option`` objects consist of a label text and a value. The value can be
+anything. If ``Option.render_value`` is set, which is set by default, the
+content of ``Option.value`` gets typecasted to a string and rendered into the
+HTML tree. This can be disabled if the actually values of the select shouldn't
+be disclosed to end users.
+
+``Select.value`` returns the value of the option that is currently
+selected. If the ``Select`` is a multi select, ``Select.value`` returns a
+tuple of all selected options values.
+
+An option can be selected by setting ``Select.value`` to the value of the
+option that should be selected, or by setting ``Option.selected``. If the
+select is no multi select, all other options get unselected automatically.
+
+**Select Attributes:**
 
 .. table::
 
-    ^Name             ^Default Value      ^Description
-    |values           |None               |(List of Tuples) Initial values
-    |bubble_up        |False              |(Bool) Pass input events further
-    |disabled         |False              |(Bool) sets the HTML attribute "disabled"
-    |multiple         |False              |(Bool) Enables multi selection
-    |*args            |()                 |Node args
-    |**kwargs         |{}                 |Node kwargs
+    ^Name              ^Description
+    |value             |Value of the currently selected option or tuple of values of selected options
+    |values            |(Tuple) tuple of all possible values
+    |options           |(Tuple) tuple of all options
+    |selected_options  |(Tuple) tuple of all selected options
+    |disabled          |(Bool) sets the HTML attribute "disabled"
+    |multiple          |(Bool) Enables multi selection
+    |id_list           |(List) contains all ids
+    |class_list        |(List) contains all classes
+    |style             |(Dict) contains all styling attributes
 
-**Attributes:**
+**Option Attributes:**
 
 .. table::
 
-    ^Name       ^Description
-    |values     |(List of Tuples) All options
-    |value      |Currently set value
-    |disabled   |(Bool) sets the HTML attribute "disabled"
-    |multiple   |(Bool) Enables multi selection
-    |id_list    |(List) contains all ids
-    |class_list |(List) contains all classes
-    |style      |(Dict) contains all styling attributes
+    ^Name              ^Description
+    |value             |value of the option
+    |selected          |(Bool) sets selection state
+    |disabled          |(Bool) sets the HTML attribute "disabled"
+    |id_list           |(List) contains all ids
+    |class_list        |(List) contains all classes
+    |style             |(Dict) contains all styling attributes
 
 
 Adding Javascript And CSS To HTML Nodes

--- a/lona/client/_lona/input-events.js
+++ b/lona/client/_lona/input-events.js
@@ -59,14 +59,17 @@ export class LonaInputEventHandler {
         if(node.getAttribute('type') == 'checkbox') {
             value = node.checked;
 
-        // select multiple
-        } else if(node.type == 'select-multiple') {
+        // select
+        } else if(node.type == 'select-one' ||
+                  node.type == 'select-multiple') {
+
+            var options = Array.from(node.options);
+
             value = [];
 
             Array.from(node.selectedOptions).forEach(option => {
-                value.push(option.value);
+                value.push(options.indexOf(option));
             });
-
         };
 
         return value;

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -5,33 +5,107 @@ from lona.html.node import Node
 class Option(Node):
     TAG_NAME = 'option'
 
+    def __init__(self, *args, value='', selected=False, disabled=False,
+                 **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self._select = None
+        self.value = value
+        self.selected = selected
+        self.disabled = disabled
+
+    def _set_selected(self, selected):
+        with self.lock:
+            if selected and 'selected' not in self.attributes:
+                self.attributes['selected'] = ''
+
+            elif not selected and 'selected' in self.attributes:
+                del self.attributes['selected']
+
+    # properties ##############################################################
+    # value
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        with self.lock:
+            self.attributes['value'] = str(new_value)
+            self._value = new_value
+
+    # selected
+    @property
+    def selected(self):
+        return 'selected' in self.attributes
+
+    @selected.setter
+    def selected(self, new_value):
+        with self.lock:
+            if self._select:
+                self._select._set_selected(self, new_value)
+
+            else:
+                self._set_selected(new_value)
+
+    # disabled
+    @property
+    def disabled(self):
+        return 'disabled' in self.attributes
+
+    @disabled.setter
+    def disabled(self, new_value):
+        if new_value:
+            self.attributes['disabled'] = ''
+
+        else:
+            del self.attributes['disabled']
+
 
 class Select(Node):
     TAG_NAME = 'select'
     EVENTS = [CHANGE]
 
-    def __init__(self, *args, values=None, disabled=False, multiple=False,
+    def __init__(self, *options, disabled=False, multiple=False,
                  readonly=False, bubble_up=False, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.values = values or []
+
+        super().__init__(**kwargs)
+
+        self.options = options
         self.disabled = disabled
         self.multiple = multiple
         self.readonly = readonly
         self.bubble_up = bubble_up
 
     def handle_input_event(self, input_event):
-        if input_event.name == 'change':
-            self.value = input_event.data
-
-            input_event = self.handle_change(input_event)
-
-            if self.bubble_up:
-                return input_event
-
-        else:
+        if input_event.name != 'change':
             return super().handle_input_event(input_event)
 
-    # properties ##############################################################
+        # select options by index
+        selected_option_indexes = input_event.data
+
+        with self.lock:
+            for index, option in enumerate(self.options):
+                option._set_selected(index in selected_option_indexes)
+
+        # run custom change event handler
+        input_event = self.handle_change(input_event)
+
+        if self.bubble_up:
+            return input_event
+
+    def _set_selected(self, option, selected):
+        with self.lock:
+            if self.multiple:
+                option._set_selected(selected)
+
+                return
+
+            for _option in self.options:
+                _option._set_selected(_option is option)
+
+    # select properties #######################################################
     # disabled
     @property
     def disabled(self):
@@ -80,73 +154,109 @@ class Select(Node):
         else:
             del self.attributes['readonly']
 
-    # values
+    # option properties #######################################################
+    # options
     @property
-    def values(self):
+    def options(self):
         with self.lock:
-            values = []
+            options = ()
 
             for node in self.nodes:
                 if node.tag_name != 'option':
                     continue
 
-                values.append(
-                    (node.attributes.get('value', ''),
-                     node.get_text(),
-                     'selected' in node.attributes),
-                )
+                options += (node, )
 
-            return values
+            return options
 
-    @values.setter
-    def values(self, new_values):
+    @options.setter
+    def options(self, new_options):
         with self.lock:
-            self.clear()
+            self.nodes.clear()
 
-            for i in new_values:
-                value, name, selected = (list(i) + [False])[0:3]
-                option_node = Option(str(name), value=str(value))
+            if not isinstance(new_options, (list, tuple)):
+                new_options = [new_options]
 
-                if selected:
-                    option_node.attributes['selected'] = ''
+            for option in new_options:
+                self.add_option(option)
 
-                self.append(option_node)
+    # selected options
+    @property
+    def selected_options(self):
+        with self.lock:
+            options = ()
+
+            for option in self.options:
+                if not option.selected:
+                    continue
+
+                options += (option, )
+
+            if not options and self.options and not self.multiple:
+                return (self.options[0], )
+
+            return options
 
     # value
     @property
     def value(self):
         with self.lock:
-            value = []
+            values = ()
 
-            for option in self.nodes:
-                if 'selected' in option.attributes:
-                    value.append(option.attributes['value'])
-
-            if not self.multiple and not value and self.nodes:
-                option = self.nodes[0]
-
-                value.append(option.attributes['value'])
-
-            if not value:
-                if not self.multiple:
-                    return None
-
-                return value
+            for option in self.selected_options:
+                values += (option.value, )
 
             if not self.multiple:
-                value = value.pop()
+                if not values:
+                    return self.options[0].value
 
-            return value
+                return values[-1]
+
+            return values
 
     @value.setter
     def value(self, new_value):
-        if not isinstance(new_value, list):
-            new_value = [new_value]
-
         with self.lock:
-            for option in self.nodes:
-                if option.attributes['value'] in new_value:
-                    option.attributes['selected'] = ''
+            if not isinstance(new_value, list):
+                new_value = [new_value]
 
-                else:
-                    del option.attributes['selected']
+            old_values = self.values
+
+            for value in new_value:
+                if value not in old_values:
+                    raise RuntimeError(f'unknown value: {value}')
+
+            for option in self.options:
+                option._set_selected(option.value in new_value)
+
+    # values
+    @property
+    def values(self):
+        with self.lock:
+            values = ()
+
+            for option in self.options:
+                values += (option.value, )
+
+            return values
+
+    # helper ##################################################################
+    def add_option(self, option):
+        with self.lock:
+            option._select = self
+            self.nodes.append(option)
+
+    def remove_option(self, option):
+        with self.lock:
+            option._select = None
+            self.nodes.remove(option)
+
+    def select_all(self):
+        with self.lock:
+            for option in self.options:
+                option.selected = True
+
+    def select_none(self):
+        with self.lock:
+            for option in self.options:
+                option.selected = False

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -143,7 +143,7 @@ class NodeHTMLParser(HTMLParser):
         node_kwargs['self_closing_tag'] = self_closing
 
         # setup node
-        for key in ('id', 'class', 'style'):
+        for key in ('id', 'class', 'style', 'value'):
             if key in node_attributes:
                 node_kwargs[key] = node_attributes.pop(key)
 

--- a/tests/test_html_select.py
+++ b/tests/test_html_select.py
@@ -1,7 +1,7 @@
 from playwright.async_api import async_playwright
 
+from lona.html import Select, Option
 from lona.pytest import eventually
-from lona.html import Select
 from lona import LonaView
 
 GET_OPTIONS = 'e => Array.from(e.selectedOptions).map(option => option.value)'
@@ -22,11 +22,9 @@ async def test_selects(lona_app_context):
         class NothingSelected(LonaView):
             def handle_request(self, request):
                 select = Select(
-                    values=[
-                        ('foo', 'Foo'),
-                        ('bar', 'Bar'),
-                        ('baz', 'Baz'),
-                    ],
+                    Option('Foo', value='foo'),
+                    Option('Bar', value='bar'),
+                    Option('Baz', value='baz'),
                     bubble_up=True,
                 )
 
@@ -41,11 +39,9 @@ async def test_selects(lona_app_context):
         class PreSelected(LonaView):
             def handle_request(self, request):
                 select = Select(
-                    values=[
-                        ('foo', 'Foo'),
-                        ('bar', 'Bar', True),
-                        ('baz', 'Baz'),
-                    ],
+                    Option('Foo', value='foo'),
+                    Option('Bar', value='bar', selected=True),
+                    Option('Baz', value='baz'),
                     bubble_up=True,
                 )
 
@@ -61,11 +57,9 @@ async def test_selects(lona_app_context):
         class MultiSelectNothingSelected(LonaView):
             def handle_request(self, request):
                 select = Select(
-                    values=[
-                        ('foo', 'Foo'),
-                        ('bar', 'Bar'),
-                        ('baz', 'Baz'),
-                    ],
+                    Option('Foo', value='foo'),
+                    Option('Bar', value='bar'),
+                    Option('Baz', value='baz'),
                     multiple=True,
                     bubble_up=True,
                 )
@@ -81,11 +75,9 @@ async def test_selects(lona_app_context):
         class MultiSelectPreSelected(LonaView):
             def handle_request(self, request):
                 select = Select(
-                    values=[
-                        ('foo', 'Foo', True),
-                        ('bar', 'Bar', True),
-                        ('baz', 'Baz'),
-                    ],
+                    Option('Foo', value='foo', selected=True),
+                    Option('Bar', value='bar', selected=True),
+                    Option('Baz', value='baz'),
                     multiple=True,
                     bubble_up=True,
                 )
@@ -163,7 +155,7 @@ async def test_selects(lona_app_context):
 
         for attempt in eventually():
             async with attempt:
-                assert test_data['multi-select/nothing-selected'] == []
+                assert test_data['multi-select/nothing-selected'] == ()
 
         # user select
         await page.select_option('select', ['foo', 'bar'])
@@ -174,10 +166,10 @@ async def test_selects(lona_app_context):
 
         for attempt in eventually():
             async with attempt:
-                assert test_data['multi-select/nothing-selected'] == [
+                assert test_data['multi-select/nothing-selected'] == (
                     'foo',
                     'bar',
-                ]
+                )
 
         # multi / pre selected ################################################
         # initial value
@@ -190,7 +182,7 @@ async def test_selects(lona_app_context):
 
         for attempt in eventually():
             async with attempt:
-                assert test_data['multi-select/pre-selected'] == ['foo', 'bar']
+                assert test_data['multi-select/pre-selected'] == ('foo', 'bar')
 
         # user select
         await page.select_option('select', ['foo', 'baz'])
@@ -201,10 +193,10 @@ async def test_selects(lona_app_context):
 
         for attempt in eventually():
             async with attempt:
-                assert test_data['multi-select/pre-selected'] == [
+                assert test_data['multi-select/pre-selected'] == (
                     'foo',
                     'baz',
-                ]
+                )
 
         # user deselect
         await page.goto(context.make_url('/multi-select/pre-selected/'))
@@ -217,4 +209,4 @@ async def test_selects(lona_app_context):
 
         for attempt in eventually():
             async with attempt:
-                assert test_data['multi-select/pre-selected'] == []
+                assert test_data['multi-select/pre-selected'] == ()


### PR DESCRIPTION
This PR refactors the `lona.html.Select` API to be more concise and convenient.