### PR TITLE
doc: make implications of awaiting input events and daemonizing clearer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,25 +53,20 @@ pythonic API to write self contained views.
 
     app = LonaApp(__file__)
 
+
     @app.route('/')
     class MyView(LonaView):
+        def handle_button_click(self, input_event):
+            self.message.set_text('Button clicked')
+
         def handle_request(self, request):
-            message = Div('Button not clicked')
-            button = Button('Click me!')
+            self.message = Div('Button not clicked')
 
             html = HTML(
                 H1('Click the button!'),
                 message,
-                button,
+                Button('Click me!', handle_click=self.handle_button_click),
             )
-
-            self.show(html)
-
-            # this call blocks until the button was clicked
-            input_event = self.await_click(button)
-
-            if input_event.node == button:
-                message.set_text('Button clicked')
 
             return html
 

--- a/doc/content/demos/counter/counter.py
+++ b/doc/content/demos/counter/counter.py
@@ -8,41 +8,38 @@ app = LonaApp(__file__)
 
 @app.route('/')
 class CounterView(LonaView):
-    def handle_request(self, request):
-        counter = Span('0')
-        number_input = NumberInput(value=10, _style={'width': '3em'})
-
-        html = HTML(
-            H1('Counter: ', counter),
-
-            number_input,
-            Button('Set', _id='set'),
-
-            Button('Decrease', _id='decrease', _style={'margin-left': '1em'}),
-            Button('Increase', _id='increase'),
+    def increase_counter(self, input_event):
+        self.counter.set_text(
+            int(self.counter.get_text()) + 1,
         )
 
-        while True:
-            self.show(html)
+    def decrease_counter(self, input_event):
+        self.counter.set_text(
+            int(self.counter.get_text()) - 1,
+        )
 
-            input_event = self.await_click()
+    def set_counter(self, input_event):
+        with contextlib.suppress(TypeError):
+            self.counter.set_text(int(self.number_input.value))
 
-            # increase
-            if input_event.node_has_id('increase'):
-                counter.set_text(
-                    int(counter.get_text()) + 1,
-                )
+    def handle_request(self, request):
+        self.counter = Span('0')
+        self.number_input = NumberInput(value=10, _style={'width': '3em'})
 
-            # decrease
-            elif input_event.node_has_id('decrease'):
-                counter.set_text(
-                    int(counter.get_text()) - 1,
-                )
+        return HTML(
+            H1('Counter: ', self.counter),
 
-            # set
-            elif input_event.node_has_id('set'):
-                with contextlib.suppress(TypeError):
-                    counter.set_text(int(number_input.value))
+            self.number_input,
+            Button('Set', _id='set', handle_click=self.set_counter),
+
+            Button(
+                'Decrease',
+                _style={'margin-left': '1em'},
+                handle_click=self.decrease_counter,
+            ),
+
+            Button('Increase', handle_click=self.increase_counter),
+        )
 
 
 app.run(port=8080)

--- a/doc/content/demos/daemonized-view/index.rst
+++ b/doc/content/demos/daemonized-view/index.rst
@@ -12,6 +12,15 @@ When ``LonaView.daemonize()`` is called, Lona lets views continue running in
 background when the user disconnects. The user can also attach multiple tabs
 to the same view then.
 
+.. note::
+
+    Daemonized views are not meant to be used to create multi-user views. They
+    are meant to create single-user views that are long running (multiple
+    minutes or hours).
+
+    For example if you write a view that process a huge amount of data, and
+    you want to push a progress bar forward.
+
 
 Install Dependencies
 --------------------

--- a/doc/content/end-user-documentation/views.rst
+++ b/doc/content/end-user-documentation/views.rst
@@ -649,17 +649,16 @@ CLICK
 
 
     class MyLonaView(LonaView):
+        def handle_click(self, input_event):
+            print(input_event.tag_name, 'was clicked')
+
         def handle_request(self, request):
-            html = HTML(
-                Div('Click me', events=[CLICK]),
-                Button('Click Me'),  # Buttons have CLICK set by default
+            return HTML(
+                Div('Click me', events=[CLICK], handle_click=self.handle_click),
+
+                # Buttons have CLICK set by default
+                Button('Click Me', handle_click=self.handle_click),
             )
-
-            while True:
-                self.show(html)
-                input_event = self.await_click()
-
-                print(input_event.tag_name, 'was clicked')
 
 
 Click events contain meta data in ``input_event.data``.
@@ -687,16 +686,13 @@ CHANGE
 
 
     class MyLonaView(LonaView):
+        def handle_change(self, input_event):
+            print('TextInput is set to', input_event.node.value)
+
         def handle_request(self, request):
-            html = HTML(
-                TextInput(value='foo', bubble_up=True),
+            return HTML(
+                TextInput(value='foo', handle_change=self.handle_change),
             )
-
-            while True:
-                self.show(html)
-                input_event = self.await_change()
-
-                print('TextInput is set to', input_event.node.value)
 
 
 FOCUS
@@ -713,16 +709,13 @@ FOCUS
 
 
     class MyLonaView(LonaView):
+        def handle_focus(self, input_event):
+            print('TextInput got focused')
+
         def handle_request(self, request):
-            html = HTML(
-                TextInput(events=[FOCUS]),
+            return HTML(
+                TextInput(events=[FOCUS], handle_focus=self.handle_focus),
             )
-
-            while True:
-                self.show(html)
-                input_event = self.await_focus()
-
-                print('TextInput got focused')
 
 
 BLUR
@@ -739,16 +732,13 @@ BLUR
 
 
     class MyLonaView(LonaView):
+        def handle_blur(self, input_event):
+            print('TextInput got blurred')
+
         def handle_request(self, request):
-            html = HTML(
-                TextInput(events=[BLUR]),
+            return HTML(
+                TextInput(events=[BLUR], handle_blur=self.handle_blur),
             )
-
-            while True:
-                self.show(html)
-                input_event = self.await_blur()
-
-                print('TextInput got blurred')
 
 
 Input Event Attributes
@@ -788,32 +778,6 @@ InputEvent.node_has_class(name)
 ```````````````````````````````
 
     Returnes ``True`` if the node associated with this event has the given class.
-
-
-Awaiting Input Events
-~~~~~~~~~~~~~~~~~~~~~
-
-Input events can be awaited from ``handle_request()``. This makes forms or
-wizards possible.
-
-.. code-block:: python
-
-    from lona.html import HTML, H1, Button
-    from lona import LonaView
-
-
-    class MyLonaView(LonaView):
-        def handle_request(self, request):
-            html = HTML(
-                H1('Click the button'),
-                Button('click me'),
-            )
-
-            self.show(html)
-
-            input_event = self.await_click()
-
-            print(input_event.node, 'was clicked')
 
 
 Handling Input events In A Callback
@@ -860,6 +824,42 @@ Callbacks can also be set by passing them directly into nodes, using the
             )
 
             self.show(html)
+
+
+Awaiting Input Events
+~~~~~~~~~~~~~~~~~~~~~
+
+Input events can be awaited from ``handle_request()``. This makes forms or
+wizards possible.
+
+.. warning::
+
+    Using ``LonaView.await_*`` means that the calling thread blocks until
+    the awaited input events gets send by the browser. This is useful when
+    writing deamonized views for interactive wizards, but might not scale
+    when the user base of your view grows.
+
+    If thread-count and scalability are crucial for you, consider using
+    `callbacks </end-user-documentation/views.html#handling-input-events-in-a-callback>`_.
+
+.. code-block:: python
+
+    from lona.html import HTML, H1, Button
+    from lona import LonaView
+
+
+    class MyLonaView(LonaView):
+        def handle_request(self, request):
+            html = HTML(
+                H1('Click the button'),
+                Button('click me'),
+            )
+
+            self.show(html)
+
+            input_event = self.await_click()
+
+            print(input_event.node, 'was clicked')
 
 
 Handling Input Events In A Hook
@@ -1054,6 +1054,14 @@ LonaView.set_title(title)
 LonaView.await_input_event\(\*nodes, html=None\)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+    .. note::
+
+        ``LonaView.await_*`` blocks the current thread until a matching
+        event gets send by the browser.
+
+        Read `Awaiting Input Events </end-user-documentation/views.html#awaiting-input-events>`_
+        for more information.
+
     Returns the next incoming input event.
 
     When ``nodes`` is set, the next input event issued by one of the given
@@ -1063,8 +1071,17 @@ LonaView.await_input_event\(\*nodes, html=None\)
     an input event
 
 
+
 LonaView.await_click\(\*nodes, html=None\)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    .. note::
+
+        ``LonaView.await_*`` blocks the current thread until a matching
+        event gets send by the browser.
+
+        Read `Awaiting Input Events </end-user-documentation/views.html#awaiting-input-events>`_
+        for more information.
 
     Returns the next incoming click event.
 
@@ -1077,6 +1094,14 @@ LonaView.await_click\(\*nodes, html=None\)
 
 LonaView.await_change\(\*nodes, html=None\)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    .. note::
+
+        ``LonaView.await_*`` blocks the current thread until a matching
+        event gets send by the browser.
+
+        Read `Awaiting Input Events </end-user-documentation/views.html#awaiting-input-events>`_
+        for more information.
 
     Returns the next incoming change event.
 
@@ -1094,6 +1119,14 @@ LonaView.await_focus\(\*nodes, html=None\)
 
         Added in 1.9
 
+    .. note::
+
+        ``LonaView.await_*`` blocks the current thread until a matching
+        event gets send by the browser.
+
+        Read `Awaiting Input Events </end-user-documentation/views.html#awaiting-input-events>`_
+        for more information.
+
     Returns the next incoming focus event.
 
     When ``nodes`` is set, the next input event issued by one of the given
@@ -1110,6 +1143,14 @@ LonaView.await_blur\(\*nodes, html=None\)
 
         Added in 1.9
 
+    .. note::
+
+        ``LonaView.await_*`` blocks the current thread until a matching
+        event gets send by the browser.
+
+        Read `Awaiting Input Events </end-user-documentation/views.html#awaiting-input-events>`_
+        for more information.
+
     Returns the next incoming blur event.
 
     When ``nodes`` is set, the next input event issued by one of the given
@@ -1123,6 +1164,18 @@ LonaView.daemonize\(\)
 ~~~~~~~~~~~~~~~~~~~~~~
 
     Allow the view to run in background after the user disconnected.
+
+    .. note::
+
+        Daemonized views are not meant to be used to create multi-user views.
+        They are meant to create single-user views that are long running
+        (multiple minutes or hours).
+
+        For example if you write a view that process a huge amount of data, and
+        you want to push a progress bar forward.
+
+        If you want to create multi-user views, use
+        `view events </end-user-documentation/views.html?q=view_event#view-events>`_.
 
 
 LonaView.iter_objects\(\)

--- a/doc/content/index.rst
+++ b/doc/content/index.rst
@@ -30,25 +30,20 @@ pythonic API to write self contained views.
 
     app = LonaApp(__file__)
 
+
     @app.route('/')
     class MyView(LonaView):
+        def handle_button_click(self, input_event):
+            self.message.set_text('Button clicked')
+
         def handle_request(self, request):
-            message = Div('Button not clicked')
-            button = Button('Click me!')
+            self.message = Div('Button not clicked')
 
             html = HTML(
                 H1('Click the button!'),
                 message,
-                button,
+                Button('Click me!', handle_click=self.handle_button_click),
             )
-
-            self.show(html)
-
-            # this call blocks until the button was clicked
-            input_event = self.await_click(button)
-
-            if input_event.node == button:
-                message.set_text('Button clicked')
 
             return html
 


### PR DESCRIPTION
Previously most examples in the documentation used the await API to retrieve input events. This API is meant for some special cases, like interactive, long-running wizards.
Also there was no clear distinction between daemonized- and multi-user views.

Users who are new to Lona, Python or Web in general (or all of them) might come to the conclusion that these are the APIs to use when creating a simple CRUD application.
This might work in simple test-cases, but will be very resource heavy with an actual user base.

This patch ports most examples to use callbacks to handle input events, and adds some clear warnings on the implications of the daemonize and the await APIs.
