### PR TITLE
tests: routing: fix pytest deprecation warning

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,7 @@ from lona.routing import Router, Route
 
 @pytest.mark.incremental()
 class TestBasicRouting:
-    def setup(self):
+    def setup_method(self):
         self.routes = [
             Route('/foo/<arg>/', None),
             Route('/foo/', None),
@@ -52,7 +52,7 @@ class TestBasicRouting:
 
 @pytest.mark.incremental()
 class TestRoutesWithRegex:
-    def setup(self):
+    def setup_method(self):
         self.routes = [
             Route('/number/<number:[0-9]+>/', None),
         ]
@@ -75,7 +75,7 @@ class TestRoutesWithRegex:
 
 @pytest.mark.incremental()
 class TestOptionalTrailingSlash:
-    def setup(self):
+    def setup_method(self):
         self.routes = [
             Route('/foo(/)', None),
             Route('/bar/', None),
@@ -128,7 +128,7 @@ class TestOptionalTrailingSlash:
 
 @pytest.mark.incremental()
 class TestReverseMatching:
-    def setup(self):
+    def setup_method(self):
         routes = [
             Route('/foo/<arg>/', None, name='foo'),
             Route('/bar/', None, name='bar'),


### PR DESCRIPTION
tests/test_routing.py::TestReverseMatching::test_reverse_with_arg_and_optional_slash
  /project/.tox/python/lib/python3.8/site-packages/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future
 release.
  tests/test_routing.py::TestReverseMatching::test_reverse_with_arg_and_optional_slash is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)

Signed-off-by: Florian Scherf <mail@florianscherf.de>