### PR TITLE
Add better implementation for `lona.html.Select`

### DIFF
--- a/doc/content/end-user-documentation/html.rst
+++ b/doc/content/end-user-documentation/html.rst
@@ -645,6 +645,10 @@ Select
 
     ``multiple`` was added in 1.6
 
+.. warning::
+
+    Deprecated since 1.12. Use `Select2 <#id1>`_ instead.
+
 
 .. code-block:: python
 
@@ -682,6 +686,78 @@ Select
     |id_list    |(List) contains all ids
     |class_list |(List) contains all classes
     |style      |(Dict) contains all styling attributes
+
+
+Select2
++++++++
+
+.. note::
+
+    Added in 1.12
+
+
+.. code-block:: python
+
+    from lona.html import Select2, Option2
+
+    select2 = Select2(
+        Option2('Option 1', value='1'),
+        Option2('Option 2', value=2),
+        Option2('Option 3', value=3.0, selected=True),
+    )
+
+    # disable first option
+    select2.options[0].disabled = True
+
+    # select second option by selected property
+    select2.options[1].selected = True
+
+    # select second option by value property
+    select2.value = 2
+
+A ``Select2`` consist of one or more ``Option2`` objects, which hold
+information on value, selection state and disabled state.
+
+``Option2`` objects consist of a label text and a value. The value can be
+anything. If ``Option2.render_value`` is set, which is set by default, the
+content of ``Option2.value`` gets typecasted to a string and rendered into the
+HTML tree. This can be disabled if the actually values of the select shouldn't
+be disclosed to end users.
+
+``Select2.value`` returns the value of the option that is currently
+selected. If the ``Select2`` is a multi select, ``Select2.value`` returns a
+tuple of all selected options values.
+
+An option can be selected by setting ``Select2.value`` to the value of the
+option that should be selected, or by setting ``Option2.selected``. If the
+select is no multi select, all other options get unselected automatically.
+
+**Select Attributes:**
+
+.. table::
+
+    ^Name              ^Description
+    |value             |Value of the currently selected option or tuple of values of selected options
+    |values            |(Tuple) tuple of all possible values
+    |options           |(Tuple) tuple of all options
+    |selected_options  |(Tuple) tuple of all selected options
+    |disabled          |(Bool) sets the HTML attribute "disabled"
+    |multiple          |(Bool) Enables multi selection
+    |id_list           |(List) contains all ids
+    |class_list        |(List) contains all classes
+    |style             |(Dict) contains all styling attributes
+
+**Option Attributes:**
+
+.. table::
+
+    ^Name              ^Description
+    |value             |value of the option
+    |selected          |(Bool) sets selection state
+    |disabled          |(Bool) sets the HTML attribute "disabled"
+    |id_list           |(List) contains all ids
+    |class_list        |(List) contains all classes
+    |style             |(Dict) contains all styling attributes
 
 
 Adding Javascript And CSS To HTML Nodes

--- a/doc/content/end-user-documentation/settings.rst
+++ b/doc/content/end-user-documentation/settings.rst
@@ -286,3 +286,22 @@ Feature Flags
           When ``lona.html.HTML`` gets initialized with multiple nodes, or
           the parsing result contains multiple nodes on the first level,
           ``lona.html.HTML`` wraps all nodes into one ``div`` node
+
+.. setting::
+    :name: USE_FUTURE_NODE_CLASSES
+    :path: lona.default_settings.USE_FUTURE_NODE_CLASSES
+
+    .. note::
+
+        Added in 1.12
+
+    Some node classes from the standard library will be replaced, in Lona 2,
+    by their newer counter-parts. All new node classes can be used immediately,
+    but when parsing HTML strings, using ``lon.html.HTML``, the old node
+    classes get used, for compatibility reasons.
+
+
+    When ``settings.USE_FUTURE_NODE_CLASSES`` is set to ``True``:
+
+
+      1. ``lona.html.Select2`` gets used instead of ``lona.html.Select``

--- a/lona/client/_lona/client/input-events.js
+++ b/lona/client/_lona/client/input-events.js
@@ -59,14 +59,17 @@ export class LonaInputEventHandler {
         if(node.getAttribute('type') == 'checkbox') {
             value = node.checked;
 
-        // select multiple
-        } else if(node.type == 'select-multiple') {
+        // select
+        } else if(node.type == 'select-one' ||
+                  node.type == 'select-multiple') {
+
+            var options = Array.from(node.options);
+
             value = [];
 
             Array.from(node.selectedOptions).forEach(option => {
-                value.push(option.value);
+                value.push(options.indexOf(option));
             });
-
         };
 
         return value;

--- a/lona/client2/_lona/client2/input-events.js
+++ b/lona/client2/_lona/client2/input-events.js
@@ -59,14 +59,17 @@ export class LonaInputEventHandler {
         if(node.getAttribute('type') == 'checkbox') {
             value = node.checked;
 
-        // select multiple
-        } else if(node.type == 'select-multiple') {
+        // select
+        } else if(node.type == 'select-one' ||
+                  node.type == 'select-multiple') {
+
+            var options = Array.from(node.options);
+
             value = [];
 
             Array.from(node.selectedOptions).forEach(option => {
-                value.push(option.value);
+                value.push(options.indexOf(option));
             });
-
         };
 
         return value;

--- a/lona/compat.py
+++ b/lona/compat.py
@@ -6,7 +6,11 @@ logger = logging.getLogger('lona')
 CLIENT_VERSION_ENV_VAR_NAME = 'LONA_CLIENT_VERSION'
 CLIENT_VERSION_ENV_VAR_VALUES = (1, 2)
 
+USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME = 'LONA_USE_FUTURE_NODE_CLASSES'
+USE_FUTURE_NODE_CLASSES_ENV_VAR_VALUES = (True, False)
 
+
+# client version ##############################################################
 def get_client_version():
     # TODO: remove in 2.0
 
@@ -35,3 +39,44 @@ def set_client_version(version):
     os.environ[CLIENT_VERSION_ENV_VAR_NAME] = version
 
     logger.debug('client version is set to %s', version)
+
+
+# future node classes #########################################################
+def get_use_future_node_classes():
+    # TODO: remove in 2.0
+
+    raw_use_future_node_classes = os.environ.get(
+        USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME,
+        'false',
+    )
+
+    use_future_node_classes = {
+        'true': True,
+        'false': False,
+        '1': True,
+        '0': False,
+    }[raw_use_future_node_classes.strip().lower()]
+
+    if use_future_node_classes not in USE_FUTURE_NODE_CLASSES_ENV_VAR_VALUES:
+        logger.error(
+            'invalid env variable: %s=%s',
+            USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME,
+            raw_use_future_node_classes,
+        )
+
+        return False
+
+    return use_future_node_classes
+
+
+def set_use_future_node_classes(enabled):
+    # TODO: remove in 2.0
+
+    if enabled not in USE_FUTURE_NODE_CLASSES_ENV_VAR_VALUES:
+        raise RuntimeError(f'invalid value for {USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME}: {enabled}')
+
+    enabled = str(enabled)
+
+    os.environ[USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME] = enabled
+
+    logger.debug('%s set to %s', USE_FUTURE_NODE_CLASSES_ENV_VAR_NAME, enabled)

--- a/lona/default_settings.py
+++ b/lona/default_settings.py
@@ -101,3 +101,4 @@ AIOHTTP_CLIENT_MAX_SIZE = 1024**2
 # feature flags
 STOP_DAEMON_WHEN_VIEW_FINISHES = True  # TODO: remove in 2.0
 CLIENT_VERSION = 1  # TODO: remove in 2.0
+USE_FUTURE_NODE_CLASSES = False  # TODO: remove in 2.0

--- a/lona/html/__init__.py
+++ b/lona/html/__init__.py
@@ -1,5 +1,6 @@
-from lona.html.data_binding.select import *  # NOQA: F403
+from lona.html.data_binding.select2 import Select2, Option2
 from lona.html.data_binding.inputs import *  # NOQA: F403
+from lona.html.data_binding.select import Select, Option
 from lona.html.parsing import _setup_node_classes_cache
 from lona.events.event_types import *  # NOQA: F403
 from lona.html.widgets import HTML as HTML1

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -3,10 +3,14 @@ from lona.html.node import Node
 
 
 class Option(Node):
+    # TODO: remove in 2.0
+
     TAG_NAME = 'option'
 
 
 class Select(Node):
+    # TODO: remove in 2.0
+
     TAG_NAME = 'select'
     EVENTS = [CHANGE]
 

--- a/lona/html/data_binding/select.py
+++ b/lona/html/data_binding/select.py
@@ -21,7 +21,15 @@ class Select(Node):
 
     def handle_input_event(self, input_event):
         if input_event.name == 'change':
-            self.value = input_event.data
+            new_value = []
+
+            for index, value in enumerate(self.values):
+                if index not in input_event.data:
+                    continue
+
+                new_value.append(value[0])
+
+            self.value = new_value
 
             input_event = self.handle_change(input_event)
 

--- a/lona/html/data_binding/select2.py
+++ b/lona/html/data_binding/select2.py
@@ -1,0 +1,264 @@
+from lona.events.event_types import CHANGE
+from lona.html.node import Node
+
+
+class Option2(Node):
+    TAG_NAME = 'option'
+
+    def __init__(
+            self,
+            *args,
+            value='',
+            selected=False,
+            disabled=False,
+            render_value=True,
+            **kwargs,
+    ):
+
+        super().__init__(*args, **kwargs)
+
+        self.render_value = render_value
+        self.value = value
+        self.selected = selected
+        self.disabled = disabled
+
+    def _render_value(self, value):
+        return str(value)
+
+    # properties ##############################################################
+    # value
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        with self.lock:
+            if self.render_value:
+                self.attributes['value'] = self._render_value(new_value)
+
+            self._value = new_value
+
+    # selected
+    @property
+    def selected(self):
+        return 'selected' in self.attributes
+
+    @selected.setter
+    def selected(self, new_value):
+        if new_value:
+            self.attributes['selected'] = ''
+
+        else:
+            del self.attributes['selected']
+
+    # disabled
+    @property
+    def disabled(self):
+        return 'disabled' in self.attributes
+
+    @disabled.setter
+    def disabled(self, new_value):
+        if new_value:
+            self.attributes['disabled'] = ''
+
+        else:
+            del self.attributes['disabled']
+
+
+class Select2(Node):
+    TAG_NAME = 'select'
+    EVENTS = [CHANGE]
+
+    def __init__(self, *options, disabled=False, multiple=False,
+                 readonly=False, bubble_up=False, **kwargs):
+
+        super().__init__(**kwargs)
+
+        self.options = options
+        self.disabled = disabled
+        self.multiple = multiple
+        self.readonly = readonly
+        self.bubble_up = bubble_up
+
+    def handle_input_event(self, input_event):
+        if input_event.name != 'change':
+            return super().handle_input_event(input_event)
+
+        # select options by index
+        selected_option_indexes = input_event.data
+
+        with self.lock:
+            for index, option in enumerate(self.options):
+                option.selected = index in selected_option_indexes
+
+        # run custom change event handler
+        input_event = self.handle_change(input_event)
+
+        if self.bubble_up:
+            return input_event
+
+    # select properties #######################################################
+    # disabled
+    @property
+    def disabled(self):
+        return 'disabled' in self.attributes
+
+    @disabled.setter
+    def disabled(self, new_value):
+        if not isinstance(new_value, bool):
+            raise TypeError('disabled is a boolean property')
+
+        if new_value:
+            self.attributes['disabled'] = ''
+
+        else:
+            del self.attributes['disabled']
+
+    # multiple
+    @property
+    def multiple(self):
+        return 'multiple' in self.attributes
+
+    @multiple.setter
+    def multiple(self, new_value):
+        if not isinstance(new_value, bool):
+            raise TypeError('multiple is a boolean property')
+
+        if new_value:
+            self.attributes['multiple'] = ''
+
+        else:
+            del self.attributes['multiple']
+
+    # readonly
+    @property
+    def readonly(self):
+        return 'readonly' in self.attributes
+
+    @readonly.setter
+    def readonly(self, new_value):
+        if not isinstance(new_value, bool):
+            raise TypeError('readonly is a boolean property')
+
+        if new_value:
+            self.attributes['readonly'] = ''
+
+        else:
+            del self.attributes['readonly']
+
+    # option properties #######################################################
+    # options
+    @property
+    def options(self):
+        with self.lock:
+            options = ()
+
+            for node in self.nodes:
+                if node.tag_name != 'option':
+                    continue
+
+                options += (node, )
+
+            return options
+
+    @options.setter
+    def options(self, new_options):
+        with self.lock:
+            self.nodes.clear()
+
+            if not isinstance(new_options, (list, tuple)):
+                new_options = [new_options]
+
+            for option in new_options:
+                self.add_option(option)
+
+    # selected options
+    @property
+    def selected_options(self):
+        with self.lock:
+            options = ()
+
+            for option in self.options:
+                if not option.selected:
+                    continue
+
+                options += (option, )
+
+            if not options and self.options and not self.multiple:
+                return (self.options[0], )
+
+            return options
+
+    # value
+    @property
+    def value(self):
+        with self.lock:
+            selected_options = self.selected_options
+            values = ()
+
+            for option in selected_options:
+                values += (option.value, )
+
+            if not self.multiple:
+                if not values:
+                    options = self.options
+
+                    if options:
+                        return self.options[0].value
+
+                    return None
+
+                return values[0]
+
+            return values
+
+    @value.setter
+    def value(self, new_value):
+        with self.lock:
+            if not isinstance(new_value, list):
+                new_value = [new_value]
+
+            old_values = self.values
+
+            for value in new_value:
+                if value not in old_values:
+                    raise RuntimeError(f'unknown value: {value}')
+
+            for option in self.options:
+                option.selected = option.value in new_value
+
+    # values
+    @property
+    def values(self):
+        with self.lock:
+            values = ()
+
+            for option in self.options:
+                values += (option.value, )
+
+            return values
+
+    # helper ##################################################################
+    def add_option(self, option):
+        with self.lock:
+            self.nodes.append(option)
+
+    def remove_option(self, option):
+        with self.lock:
+            self.nodes.remove(option)
+
+    def clear_options(self):
+        with self.lock:
+            for option in self.options:
+                option.remove()
+
+    def select_all(self):
+        with self.lock:
+            for option in self.options:
+                option.selected = True
+
+    def select_none(self):
+        with self.lock:
+            for option in self.options:
+                option.selected = False

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -144,7 +144,7 @@ class NodeHTMLParser(HTMLParser):
         node_kwargs['self_closing_tag'] = self_closing
 
         # setup node
-        for key in ('id', 'class', 'style'):
+        for key in ('id', 'class', 'style', 'value'):
             if key in node_attributes:
                 node_kwargs[key] = node_attributes.pop(key)
 

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -4,6 +4,7 @@ from html.parser import HTMLParser
 from typing import List, Dict
 import logging
 
+from lona.compat import get_use_future_node_classes
 from lona.html.abstract_node import AbstractNode
 from lona.html.text_node import TextNode
 from lona.html.nodes import Div
@@ -31,15 +32,24 @@ SELF_CLOSING_TAGS = [
     'wbr',
 ]
 
+# TODO: remove in 2.0
+FUTURE_NODE_CLASSES: dict[str, type[Node]] = {}
+
 
 def _setup_node_classes_cache():
-    from lona.html.data_binding.select2 import Select2, Option2
 
     # TODO: remove in 2.0
+    from lona.html.data_binding.select2 import Select2, Option2
+
     IGNORED_NODE_CLASSES = (
         Select2,
         Option2,
     )
+
+    FUTURE_NODE_CLASSES.update({
+        'select': Select2,
+        'option': Option2,
+    })
 
     for node_class in AbstractNode.get_all_node_classes():
         if not issubclass(node_class, Node):
@@ -90,6 +100,9 @@ class NodeHTMLParser(HTMLParser):
         self.use_high_level_nodes = use_high_level_nodes
         self.node_classes = node_classes or {}
 
+        # TODO: remove in 2.0
+        self.use_future_node_classes = get_use_future_node_classes()
+
         super().__init__(*args, **kwargs)
 
     def set_current_node(self, node):
@@ -98,6 +111,10 @@ class NodeHTMLParser(HTMLParser):
     def get_node_class(self, tag_name, attributes):
         if not self.use_high_level_nodes:
             return Node
+
+        # TODO: remove in 2.0
+        if self.use_future_node_classes and tag_name in FUTURE_NODE_CLASSES:
+            return FUTURE_NODE_CLASSES[tag_name]
 
         # inputs
         if tag_name == 'input':

--- a/lona/html/parsing.py
+++ b/lona/html/parsing.py
@@ -33,8 +33,19 @@ SELF_CLOSING_TAGS = [
 
 
 def _setup_node_classes_cache():
+    from lona.html.data_binding.select2 import Select2, Option2
+
+    # TODO: remove in 2.0
+    IGNORED_NODE_CLASSES = (
+        Select2,
+        Option2,
+    )
+
     for node_class in AbstractNode.get_all_node_classes():
         if not issubclass(node_class, Node):
+            continue
+
+        if node_class in IGNORED_NODE_CLASSES:
             continue
 
         # input nodes

--- a/lona/server.py
+++ b/lona/server.py
@@ -23,13 +23,13 @@ from typing_extensions import Literal
 from aiohttp import WSMsgType
 from jinja2 import Template
 
+from lona.compat import set_use_future_node_classes, set_client_version
 from lona.view_runtime_controller import ViewRuntimeController
 from lona.middleware_controller import MiddlewareController
 from lona.static_file_loader import StaticFileLoader
 from lona.response_parser import ResponseParser
 from lona.templating import TemplatingEngine
 from lona.imports import acquire as _acquire
-from lona.compat import set_client_version
 from lona.worker_pool import WorkerPool
 from lona.view_loader import ViewLoader
 from lona.routing import Router, Route
@@ -96,9 +96,10 @@ class Server:
 
             self.settings.update(settings_post_overrides)
 
-        # set client version
+        # set feature flags
         # TODO: remove in 2.0
         set_client_version(self.settings.CLIENT_VERSION)
+        set_use_future_node_classes(self.settings.USE_FUTURE_NODE_CLASSES)
 
         # setup aiohttp app
         server_logger.debug("starting server in '%s'", project_root)

--- a/tests/test_0001_html.py
+++ b/tests/test_0001_html.py
@@ -7,8 +7,11 @@ from lona.html import (
     TextInput,
     TextArea,
     CheckBox,
+    Select2,
+    Option2,
     Submit,
     Select,
+    Option,
     Button,
     Span,
     Node,
@@ -16,6 +19,7 @@ from lona.html import (
     Div,
     H1,
 )
+from lona.compat import set_use_future_node_classes
 
 
 @pytest.mark.incremental()
@@ -612,7 +616,26 @@ class TestHTMLFromStr:
         """)[0]
 
         assert type(node) == Select
+        assert type(node.nodes[0]) == Option
         assert node.value == '2'
+
+    def test_select2(self):
+        set_use_future_node_classes(True)
+
+        try:
+            node = HTML("""
+                <select>
+                    <option value="1">a</option>
+                    <option value="2" selected>b</option>
+                </select>
+            """)[0]
+
+            assert type(node) == Select2
+            assert type(node.nodes[0]) == Option2
+            assert node.value == '2'
+
+        finally:
+            set_use_future_node_classes(False)
 
 
 @pytest.mark.incremental()

--- a/tests/test_html_select.py
+++ b/tests/test_html_select.py
@@ -60,6 +60,25 @@ async def test_selects(browser_name, client_version, lona_app_context):
                 self.await_change(select)
                 test_data['select/pre-selected'] = select.value
 
+        @app.route('/select/value-types/')
+        class ValueTypes(View):
+            def handle_request(self, request):
+                select = Select(
+                    values=[
+                        (1,   'Integer'),
+                        (1.0, 'Float'),
+                        ('1', 'String'),
+                    ],
+                    bubble_up=True,
+                )
+
+                test_data['select/value-types'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['select/value-types'] = select.value
+
         # multi select ########################################################
         @app.route('/multi-select/nothing-selected/')
         class MultiSelectNothingSelected(View):
@@ -155,6 +174,46 @@ async def test_selects(browser_name, client_version, lona_app_context):
         for attempt in eventually():
             async with attempt:
                 assert test_data['select/pre-selected'] == 'foo'
+
+        # select / value types ################################################
+        # integer
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='Integer')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == '1'
+
+        # float
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='Float')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1.0']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == '1.0'
+
+        # string
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='String')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == '1'
 
         # multi / nothing selected ############################################
         # initial value

--- a/tests/test_html_select.py
+++ b/tests/test_html_select.py
@@ -1,4 +1,5 @@
 from playwright.async_api import async_playwright
+import pytest
 
 from lona.pytest import eventually
 from lona.html import Select
@@ -7,7 +8,9 @@ from lona import View
 GET_OPTIONS = 'e => Array.from(e.selectedOptions).map(option => option.value)'
 
 
-async def test_selects(lona_app_context):
+@pytest.mark.parametrize('client_version', [1, 2])
+@pytest.mark.parametrize('browser_name', ['chromium', 'firefox', 'webkit'])
+async def test_selects(browser_name, client_version, lona_app_context):
     """
     This test tests HTML selects and multi selects, with and without pre
     selections, using a browser.
@@ -16,6 +19,7 @@ async def test_selects(lona_app_context):
     test_data = {}
 
     def setup_app(app):
+        app.settings.CLIENT_VERSION = client_version
 
         # select ##############################################################
         @app.route('/select/nothing-selected/')
@@ -100,7 +104,7 @@ async def test_selects(lona_app_context):
     context = await lona_app_context(setup_app)
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch()
+        browser = await getattr(p, browser_name).launch()
         browser_context = await browser.new_context()
         page = await browser_context.new_page()
 

--- a/tests/test_html_select2.py
+++ b/tests/test_html_select2.py
@@ -1,0 +1,273 @@
+from playwright.async_api import async_playwright
+import pytest
+
+from lona.html import Select2, Option2
+from lona.pytest import eventually
+from lona import View
+
+GET_OPTIONS = 'e => Array.from(e.selectedOptions).map(option => option.value)'
+
+
+@pytest.mark.parametrize('client_version', [1, 2])
+@pytest.mark.parametrize('browser_name', ['chromium', 'firefox', 'webkit'])
+async def test_selects2(browser_name, client_version, lona_app_context):
+    """
+    This test tests HTML selects and multi selects, with and without pre
+    selections, using a browser.
+    """
+
+    test_data = {}
+
+    def setup_app(app):
+        app.settings.CLIENT_VERSION = client_version
+
+        # select ##############################################################
+        @app.route('/select/nothing-selected/')
+        class NothingSelected(View):
+            def handle_request(self, request):
+                select = Select2(
+                    Option2('Foo', value='foo'),
+                    Option2('Bar', value='bar'),
+                    Option2('Baz', value='baz'),
+                    bubble_up=True,
+                )
+
+                test_data['select/nothing-selected'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['select/nothing-selected'] = select.value
+
+        @app.route('/select/pre-selected/')
+        class PreSelected(View):
+            def handle_request(self, request):
+                select = Select2(
+                    Option2('Foo', value='foo'),
+                    Option2('Bar', value='bar', selected=True),
+                    Option2('Baz', value='baz'),
+                    bubble_up=True,
+                )
+
+                test_data['select/pre-selected'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['select/pre-selected'] = select.value
+
+        @app.route('/select/value-types/')
+        class ValueTypes(View):
+            def handle_request(self, request):
+                select = Select2(
+                    Option2('Integer', value=1),
+                    Option2('Float', value=1.0),
+                    Option2('String', value='1'),
+                    bubble_up=True,
+                )
+
+                test_data['select/value-types'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['select/value-types'] = select.value
+
+        # multi select ########################################################
+        @app.route('/multi-select/nothing-selected/')
+        class MultiSelectNothingSelected(View):
+            def handle_request(self, request):
+                select = Select2(
+                    Option2('Foo', value='foo'),
+                    Option2('Bar', value='bar'),
+                    Option2('Baz', value='baz'),
+                    multiple=True,
+                    bubble_up=True,
+                )
+
+                test_data['multi-select/nothing-selected'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['multi-select/nothing-selected'] = select.value
+
+        @app.route('/multi-select/pre-selected/')
+        class MultiSelectPreSelected(View):
+            def handle_request(self, request):
+                select = Select2(
+                    Option2('Foo', value='foo', selected=True),
+                    Option2('Bar', value='bar', selected=True),
+                    Option2('Baz', value='baz'),
+                    multiple=True,
+                    bubble_up=True,
+                )
+
+                test_data['multi-select/pre-selected'] = select.value
+
+                self.show(select)
+
+                self.await_change(select)
+                test_data['multi-select/pre-selected'] = select.value
+
+    context = await lona_app_context(setup_app)
+
+    async with async_playwright() as p:
+        browser = await getattr(p, browser_name).launch()
+        browser_context = await browser.new_context()
+        page = await browser_context.new_page()
+
+        # select / nothing selected ###########################################
+        # initial value
+        await page.goto(context.make_url('/select/nothing-selected/'))
+        await page.wait_for_selector('select')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['foo']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/nothing-selected'] == 'foo'
+
+        # user select
+        await page.select_option('select', 'bar')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['bar']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/nothing-selected'] == 'bar'
+
+        # select / pre selected ###############################################
+        # initial value
+        await page.goto(context.make_url('/select/pre-selected/'))
+        await page.wait_for_selector('select')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['bar']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/pre-selected'] == 'bar'
+
+        # user select
+        await page.select_option('select', 'foo')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['foo']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/pre-selected'] == 'foo'
+
+        # select / value types ################################################
+        # integer
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='Integer')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == 1
+
+        # float
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='Float')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1.0']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == 1.0
+
+        # string
+        await page.goto(context.make_url('/select/value-types/'))
+        await page.wait_for_selector('select')
+
+        await page.select_option('select', label='String')
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['1']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['select/value-types'] == '1'
+
+        # multi / nothing selected ############################################
+        # initial value
+        await page.goto(context.make_url('/multi-select/nothing-selected/'))
+        await page.wait_for_selector('select')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == []
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['multi-select/nothing-selected'] == ()
+
+        # user select
+        await page.select_option('select', ['foo', 'bar'])
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['foo', 'bar']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['multi-select/nothing-selected'] == (
+                    'foo',
+                    'bar',
+                )
+
+        # multi / pre selected ################################################
+        # initial value
+        await page.goto(context.make_url('/multi-select/pre-selected/'))
+        await page.wait_for_selector('select')
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['foo', 'bar']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['multi-select/pre-selected'] == ('foo', 'bar')
+
+        # user select
+        await page.select_option('select', ['foo', 'baz'])
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == ['foo', 'baz']
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['multi-select/pre-selected'] == (
+                    'foo',
+                    'baz',
+                )
+
+        # user deselect
+        await page.goto(context.make_url('/multi-select/pre-selected/'))
+        await page.wait_for_selector('select')
+        await page.select_option('select', [])
+
+        selected_options = await page.eval_on_selector('select', GET_OPTIONS)
+
+        assert selected_options == []
+
+        for attempt in eventually():
+            async with attempt:
+                assert test_data['multi-select/pre-selected'] == ()


### PR DESCRIPTION
This is an improved version of #276.

This PR adds an improved version of `lona.html.Select`, called `lona.html.Select2`. The new API is much simpler than the old one, because it does not use magic properties to generate `lona.html.Option` nodes and their values, but lets the user create them himself. The type of `lona.html.Option2.value` was also fixed: The old version always converted all values to strings, which is surprising inconvenient.

To make `lona.html.Select` available, using HTML string parsing, without breaking compatibility, the new nodes only get used when a feature flag is set. 