### PR TITLE
fixed typo in code for 'Nodes Are Unique'

### DIFF
--- a/doc/content/tutorial/02-html/index.rst
+++ b/doc/content/tutorial/02-html/index.rst
@@ -65,7 +65,7 @@ times, there will never be more than one reference to the same node.
     >>> div.append(span)
     >>> div.append(span)
 
-    >>> div1
+    >>> div
     <div>
         <span></span>
     </div>


### PR DESCRIPTION
There's a small typo in the code for 'Nodes Are Unique'
Should be:
>>> div