### PR TITLE
Minimal fix for NodeList.append() and accompanying test

### DIFF
--- a/lona/html/node_list.py
+++ b/lona/html/node_list.py
@@ -65,7 +65,7 @@ class NodeList:
 
             self._nodes.append(node)
 
-            index = self._nodes.index(node)
+            index = len(self._nodes) - 1
 
             self._node.document.add_patch(
                 node_id=self._node.id,

--- a/tests/REQUIREMENTS.test.txt
+++ b/tests/REQUIREMENTS.test.txt
@@ -8,5 +8,6 @@ coverage==7.2.3
 pytest==7.3.1
 pytest-aiohttp==1.0.4
 pytest-dependency==0.5.1
+pytest-mock==3.10.0
 pytest-timeout==2.1.0
 playwright==1.32.1

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,14 @@
+from lona.html import Tr, Td
+
+
+def test_number_of_serialize_calls(mocker):
+
+    from lona.html import Node
+
+    spy = mocker.spy(Node, '_serialize')
+
+    tr = Tr()
+    for i in range(100):
+        tr.append(Td(i))
+
+    assert spy.call_count < 150


### PR DESCRIPTION
Here's a minimal workaround for the performance problem caused by NodeList.append() and a small test to prove it's now performing normally. See #401 for details.