### PR TITLE
build: Bump playwright from 1.34 to 1.35

### DIFF
--- a/playwright.Dockerfile
+++ b/playwright.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.34.3-jammy
+FROM mcr.microsoft.com/playwright:v1.35.0-jammy
 
 ARG UID=1000 GID=1000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "pytest-dependency==0.5.1",
   "pytest-mock==3.10.0",
   "pytest-timeout==2.1.0",
-  "playwright==1.34.0",
+  "playwright==1.35.0",
 ]
 
 lint = [


### PR DESCRIPTION
This commit consists of two dependabot commits, which are squashed so the docker and the pip version match at all times.

build(deps): Bump playwright from v1.34.3-jammy to v1.35.0-jammy

Bumps playwright from v1.34.3-jammy to v1.35.0-jammy.

---
updated-dependencies:
- dependency-name: playwright dependency-type: direct:production ...



build(deps-dev): Bump playwright from 1.34.0 to 1.35.0

Bumps [playwright](https://github.com/Microsoft/playwright-python) from 1.34.0 to 1.35.0.
- [Release notes](https://github.com/Microsoft/playwright-python/releases)
- [Commits](https://github.com/Microsoft/playwright-python/compare/v1.34.0...v1.35.0)

---
updated-dependencies:
- dependency-name: playwright dependency-type: direct:production update-type: version-update:semver-minor ...