### PR TITLE
python: drop support for 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 	docker-compose run playwright tox $(args)
 
 ci-test:
-	docker-compose run playwright tox -e lint,py37,py38,py39,py310,py311 $(args)
+	docker-compose run playwright tox -e lint,py38,py39,py310,py311 $(args)
 
 lint:
 	docker-compose run playwright tox -e lint $(args)

--- a/lona/command_line/collect_static.py
+++ b/lona/command_line/collect_static.py
@@ -1,6 +1,4 @@
-from distutils.dir_util import copy_tree
 import shutil
-import sys
 import os
 
 from lona.logging import setup_logging
@@ -39,35 +37,7 @@ def collect_static(args):
             return
 
         if source_is_dir:
-            if sys.version_info < (3, 8):
-                # TODO: remove after Python 3.7 got removed
-                # this is necessary because the `dirs_exists_ok` flag in
-                # shutil.copytree was added in Python 3.8
-
-                for rel_source in os.listdir(source):
-                    abs_source = os.path.join(source, rel_source)
-                    abs_destination = os.path.join(destination, rel_source)
-
-                    if os.path.isdir(abs_source):
-                        if not os.path.exists(abs_destination):
-                            os.makedirs(abs_destination)
-
-                        copy_tree(
-                            src=abs_source,
-                            dst=abs_destination,
-                        )
-
-                    else:
-                        if not os.path.exists(destination):
-                            os.makedirs(destination)
-
-                        shutil.copy(
-                            src=abs_source,
-                            dst=abs_destination,
-                        )
-
-            else:
-                shutil.copytree(source, destination, dirs_exist_ok=True)
+            shutil.copytree(source, destination, dirs_exist_ok=True)
 
         else:
             shutil.copy(source, destination)

--- a/lona/command_line/handle_command_line.py
+++ b/lona/command_line/handle_command_line.py
@@ -1,6 +1,5 @@
 from argparse import RawTextHelpFormatter, ArgumentParser
 import logging
-import sys
 import os
 
 from jinja2 import Environment
@@ -44,18 +43,10 @@ def handle_command_line(argv):
         description=DESCRIPTION,
     )
 
-    # the keyword 'required' is not available in python versions lower than 3.7
-    # TODO: remove after Python3.7 was removed
-    if sys.version_info < (3, 7):
-        sub_parsers = parser.add_subparsers(
-            dest='command',
-        )
-
-    else:
-        sub_parsers = parser.add_subparsers(
-            dest='command',
-            required=True,
-        )
+    sub_parsers = parser.add_subparsers(
+        dest='command',
+        required=True,
+    )
 
     # run-server ##############################################################
     parser_run_server = sub_parsers.add_parser(
@@ -228,11 +219,6 @@ def handle_command_line(argv):
 
     # parse argv
     args = parser.parse_args(argv[1:])
-
-    # this can happen on python versions lower than 3.7
-    # TODO: remove after Python3.7 was removed
-    if not args.command:
-        exit('no sub command was given')
 
     args.settings_pre_overrides = parse_overrides(
         args.settings_pre_overrides,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Minimal supported by lona
-python_version = 3.7
+python_version = 3.8
 pretty = True
 warn_unused_configs = True
 disallow_incomplete_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 dependencies = [
   'aiohttp>=3,<4',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=py310
 
 
 [tox:jenkins]
-envlist=lint,py37,py38,py39,py310,py311
+envlist=lint,py38,py39,py310,py311
 
 
 [testenv]


### PR DESCRIPTION
Since 27. Jun 2023, Python 3.7 is end of life (https://endoflife.date/python). Thus, this patch removes support for this version.