### PR TITLE
warn if handle_request returns dict

### DIFF
--- a/lona/view_runtime.py
+++ b/lona/view_runtime.py
@@ -344,8 +344,20 @@ class ViewRuntime:
             self.send_view_start()
 
             # run view
+            handle_request_return_value=self.view.handle_request(self.request)
+            if isinstance(handle_request_return_value, dict):
+                co = self.view.handle_request.__func__.__code__
+                logger.warning(
+                   'Deprecated use of dict as return value of method'
+                   f'handle_request {co.co_filename}, line {co.co_firstlineno}'
+                )
+                logger.warning(
+                    '  (see: https://lona-web.org/1.x/api-reference'
+                    '/views.html#response-objects)'
+                )
+
             response = parse_view_return_value(
-                return_value=self.view.handle_request(self.request),
+                return_value=handle_request_return_value,
                 interactive=self.route and self.route.interactive,
             )
 


### PR DESCRIPTION
This change puts a warning in the logger if a call to `handle_request` returns a dict instead of response object.

The warning references the file and line number of the "offending" handle_request method and a link
to the Response Objects documentation.

The code could be changed to output the warning only once, but that might make the warning go unnoticed.