### PR TITLE
server: get default port optionally form environment var

### DIFF
--- a/doc/content/tutorial/01-getting-started/index.rst
+++ b/doc/content/tutorial/01-getting-started/index.rst
@@ -101,6 +101,9 @@ Run the script using:
 
 ``app.run()`` takes keywords like ``host`` or ``port`` for configuration, and
 also parses the command line. Run ``python example.py -h`` to print the help.
+If port 8080 is taken by another application, you can set environment
+variable ``LONA_DEFAULT_PORT`` to some other port, affecting all examples that 
+do not set the port explicitly.
 
 The script should print that it opened a webserver on
 ``http://localhost:8080``. If you navigate your browser there, you should see

--- a/lona/app.py
+++ b/lona/app.py
@@ -299,12 +299,14 @@ class App:
         from lona.command_line.handle_command_line import (
             parse_overrides,
             DESCRIPTION,
+            EPILOG,
         )
 
         parser = ArgumentParser(
             prog=str(self.script_path),
             formatter_class=RawTextHelpFormatter,
             description=DESCRIPTION,
+            epilog=EPILOG,
         )
 
         parser.add_argument(
@@ -428,8 +430,8 @@ class App:
 
         # setup arguments
         server_args = Namespace(
-            host='localhost',
-            port=8080,
+            host=os.environ.get('LONA_DEFAULT_HOST', 'localhost'),
+            port=os.environ.get('LONA_DEFAULT_PORT', '8080'),
             shell_server_url='',
             shutdown_timeout=0,
             log_level='info',

--- a/lona/command_line/handle_command_line.py
+++ b/lona/command_line/handle_command_line.py
@@ -16,6 +16,11 @@ Documentation: lona-web.org
 Code: https://github.com/lona-web-org/lona
 """.strip()
 
+EPILOG = """\
+You can set environment variables LONA_DEFAULT_HOST and LONA_DEFAULT_PORT,
+to override built-in defaults ('localhost' resp. '8080').
+""".rstrip()
+
 
 def parse_overrides(raw_overrides):
     environment = Environment()
@@ -110,13 +115,13 @@ def handle_command_line(argv):
     parser_run_server.add_argument(
         '--host',
         type=str,
-        default='localhost',
+        default=os.environ.get('LONA_DEFAULT_HOST', 'localhost'),
     )
 
     parser_run_server.add_argument(
         '--port',
         type=int,
-        default=8080,
+        default=os.environ.get('LONA_DEFAULT_PORT', '8080'),
     )
 
     parser_run_server.add_argument(


### PR DESCRIPTION
If the default port 8080 is taken, you have to either change the app.run() or  use --port <PORTNUM> on every invocation of the program. When trying out examples I don't want to do the first and forget the second.

This patch allows you set the environment variables LONA_DEFAULT_HOST and LONA_DEFAULT_PORT in your shell. These override the built-in defaults ('localhost' resp. 8080), and are in turn overridden by arguments to ``app.run()`` and startup commandline parameters.