### PR TITLE
Revert "build: Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
 
     # Upload coverage to codecov: https://codecov.io/
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml


### PR DESCRIPTION
Reverts lona-web-org/lona#483

This PR broke all test pipelines