### PR TITLE
client2: rendering: fix call stack limit problems in node cache

### DIFF
--- a/lona/client2/_lona/client2/rendering-engine.js
+++ b/lona/client2/_lona/client2/rendering-engine.js
@@ -104,7 +104,6 @@ export class LonaRenderingEngine {
         node.remove();
 
         this._remove_widget_if_present(node_id);
-        this._clean_node_cache();
     };
 
     _remove_widget_if_present(node_id) {
@@ -490,6 +489,7 @@ export class LonaRenderingEngine {
             const node = this._render_node(data[1]);
 
             this._set_node(node, node_id, data[0]);
+            this._clean_node_cache();
 
         // RESET
         } else if(operation == Lona.protocol.OPERATION.RESET) {
@@ -509,6 +509,7 @@ export class LonaRenderingEngine {
         // CLEAR
         } else if(operation == Lona.protocol.OPERATION.CLEAR) {
             this._clear_node(node_id);
+            this._clean_node_cache();
 
         // INSERT
         } else if(operation == Lona.protocol.OPERATION.INSERT) {
@@ -519,6 +520,7 @@ export class LonaRenderingEngine {
         // REMOVE
         } else if(operation == Lona.protocol.OPERATION.REMOVE) {
             this._remove_node(data[0]);
+            this._clean_node_cache();
 
         };
     };
@@ -635,8 +637,6 @@ export class LonaRenderingEngine {
             data.forEach(patch => {
                 this._apply_patch(patch);
             });
-
-            this._clean_node_cache();
         };
 
         this._run_widget_hooks();


### PR DESCRIPTION
Previously, the rendering of client 2 would crash when too many nodes were removed at the same time. This happened because the rendering engine method for removing a node, called the method for cleaning the node cache, and vice versa.
In theory that is correct and works, but if the amount of nodes that should be removed is big enough, the JavaScript call stack size will exceed the browsers limit.

This patch removes the dependency between the two methods and adds more careful cache cleaning calls.

Resolves #496 