### PR TITLE
tests: playwright: bump from 1.44.0 to 1.44.0

### DIFF
--- a/playwright.Dockerfile
+++ b/playwright.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.41.2-jammy
+FROM mcr.microsoft.com/playwright:v1.44.1-jammy
 
 ARG UID=1000 GID=1000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "pytest-aiohttp==1.0.5",
   "pytest-mock==3.14.0",
   "pytest-timeout==2.3.1",
-  "playwright==1.40.0",
+  "playwright==1.44.0",
 ]
 
 lint = [

--- a/tests/test_0302_responses.py
+++ b/tests/test_0302_responses.py
@@ -80,12 +80,12 @@ async def test_interactive_responses(
         url = f'/{url_prefix}responses/interactive/'
 
         await page.goto(context.make_url(url))
-        await page.wait_for_url(url)
+        await page.wait_for_url(f'**{url}')
 
         frontend_uptime = await get_frontend_uptime(page)
 
         await page.click('#lona a#redirect-response')
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
 
         assert (await get_frontend_uptime(page)) == frontend_uptime
 
@@ -93,12 +93,12 @@ async def test_interactive_responses(
         url = f'/{url_prefix}responses/interactive/'
 
         await page.goto(context.make_url(url))
-        await page.wait_for_url(url)
+        await page.wait_for_url(f'**{url}')
 
         frontend_uptime = await get_frontend_uptime(page)
 
         await page.click('#lona a#http-redirect-response')
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
 
         for attempt in eventually():
             async with attempt:

--- a/tests/test_0306_requests.py
+++ b/tests/test_0306_requests.py
@@ -45,7 +45,7 @@ async def test_post_requests(lona_app_context):
 
         # GET request
         await page.goto(context.make_url('/'))
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
 
         assert await get_method(page) == 'GET'
         assert await get_post_data(page) == {}
@@ -54,7 +54,7 @@ async def test_post_requests(lona_app_context):
         await page.locator('input[name=input-1]').fill('foo')
         await page.click('input[type=submit]')
 
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
 
         assert await get_method(page) == 'POST'
         assert await get_post_data(page) == {'input-1': 'foo'}

--- a/tests/test_0307_history.py
+++ b/tests/test_0307_history.py
@@ -54,33 +54,33 @@ async def test_client_history(
 
         # /
         await page.goto(context.make_url('/'))
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('h1:has-text("index")')
 
         # /foo
         await page.click('#foo')
-        await page.wait_for_url('/foo')
+        await page.wait_for_url('**/foo')
         await page.wait_for_selector('h1:has-text("foo")')
 
         # /bar
         await page.click('#bar')
-        await page.wait_for_url('/bar')
+        await page.wait_for_url('**/bar')
         await page.wait_for_selector('h1:has-text("bar")')
 
         # back to /foo
         await page.go_back()
-        await page.wait_for_url('/foo')
+        await page.wait_for_url('**/foo')
         await page.wait_for_selector('h1:has-text("foo")')
 
         # forward to /bar
         await page.go_forward()
-        await page.wait_for_url('/bar')
+        await page.wait_for_url('**/bar')
         await page.wait_for_selector('h1:has-text("bar")')
 
         # back to /
         await page.go_back()
         await page.go_back()
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('h1:has-text("index")')
 
         # back to external site
@@ -90,5 +90,5 @@ async def test_client_history(
         # forward to /foo
         await page.go_forward()
         await page.go_forward()
-        await page.wait_for_url('/foo')
+        await page.wait_for_url('**/foo')
         await page.wait_for_selector('h1:has-text("foo")')

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -55,7 +55,7 @@ async def test_redirects(
             initial_url = context.make_url(raw_initial_url)
 
             await page.goto(initial_url)
-            await page.wait_for_url(initial_url)
+            await page.wait_for_url(f'**{initial_url}')
 
             # trigger redirect
             await page.fill('input#url', redirect_url)
@@ -71,7 +71,7 @@ async def test_redirects(
                 await page.click('button#http-redirect')
 
             # wait for success url
-            await page.wait_for_url(success_url)
+            await page.wait_for_url(f'**{success_url}')
 
             # close page
             await page.close()

--- a/tests/test_redirects_from_event_handlers.py
+++ b/tests/test_redirects_from_event_handlers.py
@@ -97,11 +97,11 @@ async def test_redirects_from_event_handlers(response_format, lona_app_context):
             context.make_url('/redirect-from-handle-input-event-root/'),
         )
 
-        await page.wait_for_url('/redirect-from-handle-input-event-root/')
+        await page.wait_for_url('**/redirect-from-handle-input-event-root/')
 
         await page.click('button')
 
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('#lona:has-text("SUCCESS")')
 
         # test redirect from View.handle_input_event()
@@ -109,11 +109,11 @@ async def test_redirects_from_event_handlers(response_format, lona_app_context):
             context.make_url('/redirect-from-handle-input-event/'),
         )
 
-        await page.wait_for_url('/redirect-from-handle-input-event/')
+        await page.wait_for_url('**/redirect-from-handle-input-event/')
 
         await page.click('button')
 
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('#lona:has-text("SUCCESS")')
 
         # test redirect from button
@@ -121,11 +121,11 @@ async def test_redirects_from_event_handlers(response_format, lona_app_context):
             context.make_url('/redirect-from-button/'),
         )
 
-        await page.wait_for_url('/redirect-from-button/')
+        await page.wait_for_url('**/redirect-from-button/')
 
         await page.click('button')
 
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('#lona:has-text("SUCCESS")')
 
         # test redirect from View.on_view_event()
@@ -133,10 +133,10 @@ async def test_redirects_from_event_handlers(response_format, lona_app_context):
             context.make_url('/redirect-from-on-view-event/'),
         )
 
-        await page.wait_for_url('/redirect-from-on-view-event/')
+        await page.wait_for_url('**/redirect-from-on-view-event/')
         await page.wait_for_selector('#lona:has-text("REDIRECT FROM ON VIEW EVENT")')
 
         context.server.fire_view_event('foo')
 
-        await page.wait_for_url('/')
+        await page.wait_for_url('**/')
         await page.wait_for_selector('#lona:has-text("SUCCESS")')


### PR DESCRIPTION
Somewhere between Playwright 1.40 and 1.44, `Page.wait_for_url()` changed behavior. Now, only URLs, starting with wildcards, seem to work for our usecase.

I am not sure why that was changed, or why this is a problem in our test, but the change in this patch is in line with the documentation of `Page.wait_for_url()`, so it should be fine.