### PR TITLE
Settingsloader: Fail on Error

### DIFF
--- a/lona/command_line/handle_command_line.py
+++ b/lona/command_line/handle_command_line.py
@@ -1,5 +1,6 @@
 from argparse import RawTextHelpFormatter, ArgumentParser
 import logging
+import sys
 import os
 
 from watchfiles import run_process
@@ -32,7 +33,7 @@ def parse_overrides(raw_overrides):
             logger.error(
                 "settings overrides: invalid format: '%s'", override)
 
-            continue
+            sys.exit(1)
 
         name, value = override.split('=', 1)
         value = environment.compile_expression(value)()

--- a/lona/settings.py
+++ b/lona/settings.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import logging
 import types
 import runpy
+import sys
 
 logger = logging.getLogger('lona.settings')
 
@@ -18,7 +19,7 @@ class Settings:
                 path,
             )
 
-            return
+            sys.exit(1)
 
         self._paths.append(path)
 
@@ -35,7 +36,7 @@ class Settings:
                 path,
             )
 
-            return
+            sys.exit(1)
 
         self._values = {}
 


### PR DESCRIPTION
Loading settings is a very early step when starting up Lona. In case that a settings file or a settings override can not be loaded or parsed Lona currently continues to start. But will very likely not be configured in a way that the user expect or want. For example:

```
$ lona run-server -s does_not_exist.py
MainThread                     ERROR    11:39:42.919306 lona.settings exception raised while loading settings '/home/chris/(...)/does_not_exist.py'
  Traceback (most recent call last):                                                                                                                                                                                                                                                                                
    File "/home/chris/(...)/env/lib/python3.13/site-packages/lona/settings.py", line 26, in add                                                                                                                                                                                         
      values = runpy.run_path(                                                                                                                                                                                                                                                                                      
          path,                                                                                                                                                                                                                                                                                                     
          init_globals=self._values,                                                                                                                                                                                                                                                                                
          run_name=path,                                                                                                                                                                                                                                                                                            
      )                                                                                                                                                                                                                                                                                                             
    File "<frozen runpy>", line 286, in run_path                                                                                                                                                                                                                                                                    
    File "<frozen runpy>", line 254, in _get_code_from_file                                                                                                                                                                                                                                                         
  FileNotFoundError: [Errno 2] No such file or directory: '/home/chris/(...)/does_not_exist.py'                                                                                                                                                                                         
MainThread                     WARNING  11:39:42.920526 lona.server routing table is empty
/home/chris/(...)/env/lib/python3.13/site-packages/lona/templating.py:44: Lona_2_0_DeprecationWarning: client_version() will be removed in 2.0
  lona.warnings.remove_2_0()
======== Running on http://localhost:8080 ========
(Press CTRL+C to quit)
```

With this change Lona will simply refuse to start up and exit with `rc=1`.
This way a script or service running Lona can catch and report the misconfiguration:

```
lona run-server -s does_not_exist.py; echo $?
MainThread                     ERROR    11:31:59.257469 lona.settings exception raised while loading settings '/home/chris/(...)/does_not_exist.py'
  Traceback (most recent call last):                                                                                                                                                                                                                                                                                
    File "/home/chris/(...)/env/lib/python3.13/site-packages/lona/settings.py", line 27, in add                                                                                                                                                                                         
      values = runpy.run_path(                                                                                                                                                                                                                                                                                      
          path,                                                                                                                                                                                                                                                                                                     
          init_globals=self._values,                                                                                                                                                                                                                                                                                
          run_name=path,                                                                                                                                                                                                                                                                                            
      )                                                                                                                                                                                                                                                                                                             
    File "<frozen runpy>", line 286, in run_path                                                                                                                                                                                                                                                                    
    File "<frozen runpy>", line 254, in _get_code_from_file                                                                                                                                                                                                                                                         
  FileNotFoundError: [Errno 2] No such file or directory: '/home/chris/(...)/does_not_exist.py'                                                                                                                                                                                         
1
```