### PR TITLE
server: reverse: fix kwargs type annotation

### DIFF
--- a/lona/server.py
+++ b/lona/server.py
@@ -990,7 +990,7 @@ class Server:
             self,
             route_name: str,
             *args: Any,
-            **kwargs: dict[str, Any],
+            **kwargs: Any,
     ) -> str:
 
         """


### PR DESCRIPTION
Hey,

when annotating kwargs the type annotation refers to the type of the items within the dict [^1]. This is already done correctly around the codebase, except for `Server.reverse`.

Let's drop the dict there as well so my language server will stop yelling at me :)

Thanks!

[^1]: https://typing.python.org/en/latest/spec/callables.html#annotating-args-and-kwargs